### PR TITLE
Better readability for browsers with dark themes.

### DIFF
--- a/themes/material/css/form.css
+++ b/themes/material/css/form.css
@@ -96,6 +96,7 @@ form > div > textarea {
     padding-top: 5rem;
     width: 100%;
     background-color: transparent;
+    color: black;
     border-bottom: 1px solid rgba(0, 0, 0, 0.12);
     margin-bottom: 1rem;
 


### PR DESCRIPTION
Text entries are hard to read on browsers or desktops that use dark themes. Forcing the color to black solves the issue.
