### PR TITLE
Fix pubsub configure form

### DIFF
--- a/lib/XMPPtoForm.php
+++ b/lib/XMPPtoForm.php
@@ -297,8 +297,9 @@ class XMPPtoForm{
         }
         else{
             foreach($s->value as $option){
+                $label = $option['label'];
                 $option = $this->html->createElement('option', $option);
-                $option->setAttribute('value', $option['label']);
+                $option->setAttribute('value', $label);
                 $option->setAttribute('selected', 'selected');
                 $select->appendChild($option);
             }


### PR DESCRIPTION
Not sure if it really does the right thing, but I works for me. I guess

```
$option = $this->html->createElement('option', $option);
$option->setAttribute('value', $option['label']);
```

can't work. I get the following error:

```
PHP Fatal error:  Cannot use object of type DOMElement as array in /var/www/movim/lib/XMPPtoForm.php on line 301
```

I'm using: ejabberd 15.10.XX, PHP 5.6.15-1+deb.sury.org~precise
