### PR TITLE
daemon: listen on loopback only

### DIFF
--- a/daemon.php
+++ b/daemon.php
@@ -49,7 +49,7 @@ $core = new Core($loop, $argv[1], $argv[2]);
 $app  = new HttpServer(new WsServer($core));
 
 $socket = new Reactor($loop);
-$socket->listen($argv[2], '0.0.0.0');
+$socket->listen($argv[2], '127.0.0.1');
 
 $socketApi = new Reactor($loop);
 new Api($socketApi, $core);


### PR DESCRIPTION
The Movim daemon and the apache server are on the same computer.
Apache will redirect the websocket to ws://localhost:8080/ so the daemon
only has to listen to the localhost (loopback) interface.

The Movim daemon is then no more available from the Internet.
