### PR TITLE
Check that DOCUMENT_ROOT is writable only if errors

### DIFF
--- a/src/Movim/Bootstrap.php
+++ b/src/Movim/Bootstrap.php
@@ -46,23 +46,22 @@ class Bootstrap
         );
         $errors = [];
 
-        if(!is_writable(DOCUMENT_ROOT))
+        if(!file_exists(DOCUMENT_ROOT.'/cache') && !@mkdir(DOCUMENT_ROOT.'/cache')) {
+            $errors[] = 'Couldn\'t create directory cache';
+        }
+        if(!file_exists(DOCUMENT_ROOT.'/log') && !@mkdir(DOCUMENT_ROOT.'/log')) {
+            $errors[] = 'Couldn\'t create directory log';
+        }
+        if(!file_exists(DOCUMENT_ROOT.'/config') && !@mkdir(DOCUMENT_ROOT.'/config')) {
+            $errors[] = 'Couldn\'t create directory config';
+        }
+        if(!file_exists(DOCUMENT_ROOT.'/users') && !@mkdir(DOCUMENT_ROOT.'/users')) {
+            $errors[] = 'Couldn\'t create directory users';
+        } else {
+            touch(DOCUMENT_ROOT.'/users/index.html');
+        }
+        if(!empty($errors) && !is_writable(DOCUMENT_ROOT))
             $errors[] = 'We\'re unable to write to folder '.DOCUMENT_ROOT.': check rights';
-        else {
-            if(!file_exists(DOCUMENT_ROOT.'/cache') && !@mkdir(DOCUMENT_ROOT.'/cache')) {
-                $errors[] = 'Couldn\'t create directory cache';
-            }
-            if(!file_exists(DOCUMENT_ROOT.'/log') && !@mkdir(DOCUMENT_ROOT.'/log')) {
-                $errors[] = 'Couldn\'t create directory log';
-            }
-            if(!file_exists(DOCUMENT_ROOT.'/config') && !@mkdir(DOCUMENT_ROOT.'/config')) {
-                $errors[] = 'Couldn\'t create directory config';
-            }
-            if(!file_exists(DOCUMENT_ROOT.'/users') && !@mkdir(DOCUMENT_ROOT.'/users')) {
-                $errors[] = 'Couldn\'t create directory users';
-            } else {
-                touch(DOCUMENT_ROOT.'/users/index.html');
-            }
         }
 
         foreach($listWritableFile as $fileName) {


### PR DESCRIPTION
This check is only needed to tell the user folders can't be created, so it's not necessary if they are already present.