### PR TITLE
Fix lack of color for certains nicks/strings

### DIFF
--- a/app/helpers/StringHelper.php
+++ b/app/helpers/StringHelper.php
@@ -239,7 +239,7 @@ function stringToColor($string)
         7 => 'brown'
     ];
 
-    $s = crc32($string);
+    $s = abs(crc32($string));
     return $colors[$s%8];
 }
 


### PR DESCRIPTION
Not sure why I seem to be the only one experiencing this issue, but I noticed that the crc32 hash used to randomize the color of nicks/strings sometimes returns negative value. And apparently in PHP, [a modulo on a negative int returns a negative int](http://stackoverflow.com/questions/4409281/how-is-13-64-13-in-php). As a result, no color is assigned, which defaults to black, and half the nicks in chats are black.

Fixed it by taking `abs()` of the value returned by crc32.