### PR TITLE
Fix http error codes management

### DIFF
--- a/app/widgets/Upload/upload.js
+++ b/app/widgets/Upload/upload.js
@@ -109,13 +109,13 @@ var Upload = {
 
         Upload.xhr.onreadystatechange = function() {
             if(Upload.xhr.readyState == 4
-            && (Upload.xhr.status == 200 || Upload.xhr.status == 201)) {
+            && (Upload.xhr.status >= 200 && Upload.xhr.status < 400)) {
                 Dialog.clear();
                 Upload.launchAttached();
             }
 
             if(Upload.xhr.readyState == 4
-            && Upload.xhr.status != 200) {
+            && Upload.xhr.status >= 400) {
                 Upload_ajaxFailed();
             }
         }


### PR DESCRIPTION
XEP-0363 specifies a "201 Created" response code (on PUT request) as a successful upload, but a proper HTTP client should manage < 400 responses as something different than an error.

The management for each response code must be implemented.