### PR TITLE
Prevent middle click scrolling

### DIFF
--- a/app/widgets/Chats/chats.js
+++ b/app/widgets/Chats/chats.js
@@ -26,6 +26,7 @@ var Chats = {
                         Chats_ajaxClose(this.dataset.jid);
                         delete document.querySelector('#chat_widget').dataset.jid;
                         MovimTpl.hidePanel();
+                        e.preventDefault();
                     }
                 }
             }


### PR DESCRIPTION
Add call to preventDefault to stop middle click scrolling becoming active when using middle button to close a chat in Chrome.