### PR TITLE
Fix typo from 'theses' to 'these'.

### DIFF
--- a/app/widgets/Login/locales.ini
+++ b/app/widgets/Login/locales.ini
@@ -25,7 +25,7 @@ password           = Password
 create_one         = Create one !
 no_account         = No account yet ?
 
-whitelist_info     = You can login with accounts from theses servers
+whitelist_info     = You can login with accounts from these servers
 connected          = Connected
 population         = Population
 


### PR DESCRIPTION
Fixes a little typo on the login page when you have the server whitelist enabled. As far as I can see this typo is the same in all locale files.