### PR TITLE
Tab nicknames autocompletion in MUCs, version 1

### DIFF
--- a/app/widgets/Chat/chat.js
+++ b/app/widgets/Chat/chat.js
@@ -30,56 +30,67 @@ var Chat = {
 
         // If user have deleted text from textarea - reinitialize
         // autocompletion.
-        if (text == "" && Chat.previouslyAutocompleted !== null) {
+        if (text == '' && Chat.previouslyAutocompleted !== null) {
             Chat.previouslyAutocompleted = null;
             Chat.previouslyAutocompletedSeqID = null;
         }
 
         // Assume that this is what we want to autocomplete if
         // Chat.toAutocomplete is null.
-        if (Chat.toAutocomplete === null || (Chat.toAutocomplete != text && text.indexOf(":") === -1)) {
+        if (Chat.toAutocomplete === null
+            || (
+                Chat.toAutocomplete != text
+                && text.indexOf(':') === -1)
+            ) {
             Chat.toAutocomplete = text;
         }
 
         // If it is a first autocomplete attempt and there was no
         // substring to search found in input field - just add
         // first element from users list to input field.
-        if (Chat.previouslyAutocompleted === null && Chat.toAutocomplete == "") {
-            var autocompleted = usersList[0]["resource"];
-            textarea.value = autocompleted + ": ";
+        if (Chat.previouslyAutocompleted === null
+            && Chat.toAutocomplete == '') {
+            var autocompleted = usersList[0]['resource'];
+            textarea.value = autocompleted + ': ';
             Chat.previouslyAutocompleted = autocompleted;
         } else {
             // Otherwise we should autocomplete next to
             // previouslyAutocompleted.
-            var autocompleted_ok = false;
+            var autocompletedOk = false;
             for (var i = 0; i < usersList.length; i++) {
-                var autocompleted = "";
+                var autocompleted = '';
                 // If we want to just-scroll thru all people in MUC.
-                if (usersList[i]["resource"] == Chat.previouslyAutocompleted && i !== usersList.length - 1 && Chat.toAutocomplete == "") {
-                    autocompleted = usersList[i+1]["resource"];
-                    textarea.value = autocompleted + ": ";
+                if (usersList[i]['resource'] == Chat.previouslyAutocompleted
+                    && i !== usersList.length - 1
+                    && Chat.toAutocomplete == '') {
+                    autocompleted = usersList[i+1]['resource'];
+                    textarea.value = autocompleted + ': ';
                     Chat.previouslyAutocompleted = autocompleted;
                     Chat.previouslyAutocompletedSeqID = i;
-                    autocompleted_ok = true;
+                    autocompletedOk = true;
                     break;
                 } else {
                     // If we have substring to autocomplete.
-                    if (i > Chat.previouslyAutocompletedSeqID && usersList[i]["resource"].substring(0, Chat.toAutocomplete.length).toLowerCase().indexOf(Chat.toAutocomplete) !== -1 && usersList[i]["resource"] != Chat.previouslyAutocompleted) {
-                        autocompleted = usersList[i]["resource"];
-                        textarea.value = autocompleted + ": ";
+                    var user_substr = usersList[i]['resource'].substring(0,
+                        Chat.toAutocomplete.length)
+                    if (i > Chat.previouslyAutocompletedSeqID
+                        && user_substr.toLowerCase().indexOf(Chat.toAutocomplete) !== -1
+                        && usersList[i]['resource'] != Chat.previouslyAutocompleted) {
+                        autocompleted = usersList[i]['resource'];
+                        textarea.value = autocompleted + ': ';
                         Chat.previouslyAutocompleted = autocompleted;
                         Chat.previouslyAutocompletedSeqID = i;
-                        autocompleted_ok = true;
+                        autocompletedOk = true;
                         break;
                     }
                 }
-                if (autocompleted_ok) {
+                if (autocompletedOk) {
                     break;
                 }
             }
             // If autocompletion failed - emptify input field.
-            if (!autocompleted_ok) {
-                textarea.value = "";
+            if (!autocompletedOk) {
+                textarea.value = '';
                 Chat.previouslyAutocompleted = null;
                 Chat.previouslyAutocompletedSeqID = null;
             }
@@ -144,10 +155,8 @@ var Chat = {
         }, 0); // Fix Me
 
         textarea.onkeydown = function(event) {
-            if (this.dataset.muc) {
-                if (event.keyCode == 9) {
-                    Chat.autocomplete(event, this.dataset.jid);
-                }
+            if (this.dataset.muc && event.keyCode == 9) {
+                Chat.autocomplete(event, this.dataset.jid);
                 return;
             }
 

--- a/app/widgets/Chat/chat.js
+++ b/app/widgets/Chat/chat.js
@@ -31,6 +31,13 @@ var Chat = {
         var textarea = document.querySelector('#chat_textarea');
         var text = textarea.value.toLowerCase();
 
+        // If user have deleted text from textarea - reinitialize
+        // autocompletion.
+        if (text == "" && Chat.previouslyAutocompleted !== null) {
+            Chat.previouslyAutocompleted = null;
+            Chat.previouslyAutocompletedSeqID = null;
+        }
+
         // Assume that this is what we want to autocomplete if
         // Chat.toAutocomplete is null.
         if (Chat.toAutocomplete === null || (Chat.toAutocomplete != text && text.indexOf(":") === -1)) {
@@ -80,6 +87,7 @@ var Chat = {
             if (!autocompleted_ok) {
                 textarea.value = "";
                 Chat.previouslyAutocompleted = null;
+                Chat.previouslyAutocompletedSeqID = null;
             }
         }
     },

--- a/app/widgets/Chat/chat.js
+++ b/app/widgets/Chat/chat.js
@@ -107,6 +107,13 @@ var Chat = {
                 Chat_ajaxSendMessage(jid, text, muc);
             }
         }
+
+        // Emptify autocomplete data on message sending.
+        if (Chat.previouslyAutocompleted !== null) {
+            Chat.previouslyAutocompleted = null;
+            Chat.previouslyAutocompletedSeqID = null;
+            Chat.toAutocomplete = null;
+        }
     },
     sendedMessage: function()
     {

--- a/app/widgets/Chat/chat.js
+++ b/app/widgets/Chat/chat.js
@@ -18,6 +18,7 @@ var Chat = {
     toAutocomplete: null,
     // What was previously in autocomplete?
     previouslyAutocompleted: null,
+    previouslyAutocompletedSeqID: null,
 
     autocomplete: function(event, jid) {
         event.preventDefault();
@@ -36,6 +37,7 @@ var Chat = {
             console.log("toAutocomplete changed: " + text);
             Chat.toAutocomplete = text;
         }
+        console.log("toAutocomplete: " + Chat.toAutocomplete);
 
         // If it is a first autocomplete attempt and there was no
         // substring to search found in input field - just add
@@ -53,24 +55,25 @@ var Chat = {
                 // If we want to just-scroll thru all people in MUC.
                 if (usersList[i]["resource"] == Chat.previouslyAutocompleted && i !== usersList.length - 1 && Chat.toAutocomplete == "") {
                     autocompleted = usersList[i+1]["resource"];
-                    console.log(autocompleted);
                     textarea.value = autocompleted + ": ";
                     Chat.previouslyAutocompleted = autocompleted;
+                    Chat.previouslyAutocompletedSeqID = i;
                     autocompleted_ok = true;
                     break;
                 } else {
                     // If we have substring to autocomplete.
-                    for (var ii = i; ii < usersList.length; ii++) {
-                        console.log(usersList[ii]["resource"].toLowerCase());
-                        if (usersList[ii]["resource"].toLowerCase().indexOf(text) !== -1) {
-                            autocompleted = usersList[i]["resource"];
-                            console.log(autocompleted);
-                            textarea.value = autocompleted + ": ";
-                            Chat.previouslyAutocompleted = autocompleted;
-                            autocompleted_ok = true;
-                            break;
-                        }
+                    if (i > Chat.previouslyAutocompletedSeqID && usersList[i]["resource"].toLowerCase().indexOf(Chat.toAutocomplete) !== -1 && usersList[i]["resource"] != Chat.previouslyAutocompleted) {
+                        console.log("BREAK")
+                        autocompleted = usersList[i]["resource"];
+                        textarea.value = autocompleted + ": ";
+                        Chat.previouslyAutocompleted = autocompleted;
+                        Chat.previouslyAutocompletedSeqID = i;
+                        autocompleted_ok = true;
+                        break;
                     }
+                }
+                if (autocompleted_ok) {
+                    break;
                 }
             }
             // If autocompletion failed - emptify input field.

--- a/app/widgets/Chat/chat.js
+++ b/app/widgets/Chat/chat.js
@@ -25,9 +25,6 @@ var Chat = {
         Rooms_ajaxMucUsersAutocomplete(jid);
     },
     onAutocomplete: function(usersList) {
-        console.log("onAutocomplete");
-        console.log(usersList);
-
         var textarea = document.querySelector('#chat_textarea');
         var text = textarea.value.toLowerCase();
 
@@ -41,10 +38,8 @@ var Chat = {
         // Assume that this is what we want to autocomplete if
         // Chat.toAutocomplete is null.
         if (Chat.toAutocomplete === null || (Chat.toAutocomplete != text && text.indexOf(":") === -1)) {
-            console.log("toAutocomplete changed: " + text);
             Chat.toAutocomplete = text;
         }
-        console.log("toAutocomplete: " + Chat.toAutocomplete);
 
         // If it is a first autocomplete attempt and there was no
         // substring to search found in input field - just add
@@ -69,8 +64,7 @@ var Chat = {
                     break;
                 } else {
                     // If we have substring to autocomplete.
-                    if (i > Chat.previouslyAutocompletedSeqID && usersList[i]["resource"].toLowerCase().indexOf(Chat.toAutocomplete) !== -1 && usersList[i]["resource"] != Chat.previouslyAutocompleted) {
-                        console.log("BREAK")
+                    if (i > Chat.previouslyAutocompletedSeqID && usersList[i]["resource"].substring(0, Chat.toAutocomplete.length).toLowerCase().indexOf(Chat.toAutocomplete) !== -1 && usersList[i]["resource"] != Chat.previouslyAutocompleted) {
                         autocompleted = usersList[i]["resource"];
                         textarea.value = autocompleted + ": ";
                         Chat.previouslyAutocompleted = autocompleted;

--- a/app/widgets/Rooms/Rooms.php
+++ b/app/widgets/Rooms/Rooms.php
@@ -191,7 +191,7 @@ class Rooms extends \Movim\Widget\Base
 
         $view = $this->tpl();
 
-        $userslist = $this->ajaxListGetUsers($room);
+        $userslist = $this->getUsersList($room);
         $view->assign('list', $userslist);
         $view->assign('me', $this->user->getLogin());
 
@@ -199,19 +199,10 @@ class Rooms extends \Movim\Widget\Base
     }
 
     /**
-     * @brief Get rooms users list
-     */
-    function ajaxListGetUsers($room)
-    {
-        $cd = new \Modl\ContactDAO;
-        return $cd->getPresences($room);
-    }
-
-    /**
      * @brief Autocomplete users in MUC
      */
     function ajaxMucUsersAutocomplete($room) {
-        $usersForAutocomplete = $this->ajaxListGetUsers($room);
+        $usersForAutocomplete = $this->getUsersList($room);
         $this->rpc("Chat.onAutocomplete", $usersForAutocomplete);
     }
 
@@ -370,6 +361,15 @@ class Rooms extends \Movim\Widget\Base
         } else {
             return false;
         }
+    }
+
+    /**
+     * @brief Get rooms users list
+     */
+    function getUsersList($room)
+    {
+        $cd = new \Modl\ContactDAO;
+        return $cd->getPresences($room);
     }
 
     function prepareRooms($edit = false)

--- a/app/widgets/Rooms/Rooms.php
+++ b/app/widgets/Rooms/Rooms.php
@@ -191,11 +191,28 @@ class Rooms extends \Movim\Widget\Base
 
         $view = $this->tpl();
 
-        $cd = new \Modl\ContactDAO;
-        $view->assign('list', $cd->getPresences($room));
+        $userslist = $this->ajaxListGetUsers($room);
+        $view->assign('list', $userslist);
         $view->assign('me', $this->user->getLogin());
 
         Dialog::fill($view->draw('_rooms_list', true), true);
+    }
+
+    /**
+     * @brief Get rooms users list
+     */
+    function ajaxListGetUsers($room)
+    {
+        $cd = new \Modl\ContactDAO;
+        return $cd->getPresences($room);
+    }
+
+    /**
+     * @brief Autocomplete users in MUC
+     */
+    function ajaxMucUsersAutocomplete($room) {
+        $usersForAutocomplete = $this->ajaxListGetUsers($room);
+        $this->rpc("Chat.onAutocomplete", $usersForAutocomplete);
     }
 
     /**


### PR DESCRIPTION
This PR makes possible to autocomplete nicknames in MUCs with TAB key.

It can autocomplete in two ways:

1. Just-scroll-over-all-users: when input field in empty and user pressing tab.
2. Exact nickname(s) autocomplete: when input field contains a string that can be found in nickname.

On failed autocompletion it will emptify input field (e.g. users list is over or nothing to autocomplete).

Changes made:

* In ``app/widgets/Chat/chat.js`` added two functions:
  *  ``Chat.autocomplete`` - used to prevent default action (switch focus from one element to another)
  * ``Chat.onAutocomplete`` - autocompletion inself, which searching thru obtained users list and do autocompletion stuff.
* In ``app/widgets/Rooms/Rooms.php`` added two functions:
  * ``ajaxListGetUsers``o - "obtainer" of users list in MUC
  * ``ajaxMucUsersAutocomplete`` - autocompletion call handler.

Also changed ``ajaxList`` function to re-use ``ajaxListGetUsers`` function, so autocompletion and users list dialog will get same data. Maybe, ``ajaxListGetUsers`` should be renamed or put somewhere else?

Should fix movim/movim#151