### PR TITLE
Account for self-hosted HipChat instances.

### DIFF
--- a/app/models/message/Message.php
+++ b/app/models/message/Message.php
@@ -112,7 +112,8 @@ class Message extends Model
             }
 
             # HipChat MUC specific cards
-            if(explodeJid($this->jidfrom)['server'] == 'conf.hipchat.com'
+            if((explodeJid($this->jidfrom)['server'] == 'conf.hipchat.com'
+            || explodeJid($this->jidfrom)['server'] == 'conf.btf.hipchat.com')
             && $this->type == 'groupchat'
             && $stanza->x
             && $stanza->x->attributes()->xmlns == 'http://hipchat.com/protocol/muc#room'


### PR DESCRIPTION
Self-hosted HipChat instances are (currently) hard-coded to the *.btf.hipchat.com domain, so it is easy to catch those as well to support their protocol extension to MUC cards.