### PR TITLE
Update Content-Security-Policy

### DIFF
--- a/app/views/page.tpl
+++ b/app/views/page.tpl
@@ -5,7 +5,7 @@
     <title><?php $this->title(); ?></title>
 
     <meta name="theme-color" content="#1C1D5B" />
-    <meta http-equiv="Content-Security-Policy" content="font-src 'self'; child-src *.youtube.com; script-src 'self' 'unsafe-inline' 'unsafe-eval'">
+    <meta http-equiv="Content-Security-Policy" content="font-src <?php echo BASE_URI; ?>; child-src *.youtube.com; script-src <?php echo BASE_URI; ?> 'unsafe-inline' 'unsafe-eval'">
 
     <?php $this->meta(); ?>
 

--- a/app/views/page.tpl
+++ b/app/views/page.tpl
@@ -5,7 +5,7 @@
     <title><?php $this->title(); ?></title>
 
     <meta name="theme-color" content="#1C1D5B" />
-    <meta http-equiv="Content-Security-Policy" content="font-src <?php echo BASE_URI; ?>; child-src *.youtube.com; script-src <?php echo BASE_URI; ?> 'unsafe-inline' 'unsafe-eval'">
+    <meta http-equiv="Content-Security-Policy" content="font-src <?php echo BASE_URI; ?>; frame-src *.youtube.com; script-src <?php echo BASE_URI; ?> 'unsafe-inline' 'unsafe-eval'">
 
     <?php $this->meta(); ?>
 


### PR DESCRIPTION
Hello,

I wanted to update the page.tpl template to replace the use of 'self' by use of the exact PHP BASE_URI instead.

The idea behind this update is to allow this configuration:

1. My movim instance is located at `https://mov.adorsaz.ch`
2. I have a Movim blog here: `https://mov.adorsaz.ch/blog/adrien%40adorsaz.ch`
3. I have another domain pointing directly to my Movim blog by using an Apache2 Proxy: `https://adorsaz.ch` displays the page `https://mov.adorsaz.ch/blog/adrien%40adorsaz.ch`

Without this modification, when a user visits the adorsaz.ch domain, he doesn't get the fonts. Indeed, currently the CSP rules fonts to be downloaded from `'self'`. Although, in such situation, font URI sources are still targeting `mov.adorsaz.ch` and `'self'` is targetting `adorsaz.ch`.

With this fix, we avoid the use of the ambiguous `'self'` CSP directive by explicitly giving the URI of the Movim pod installation.

Although I'm not familiar with CSP, maybe that's not a good idea ?

Furhtermore, as I was debugging the CSP, Firefox Nightly sayed me that child-src directive is depreciated. So, as Movim includes Youtube videos as frame, I've replaced `child-src` by `frame-src` (which is now back valid, according to Google: https://developers.google.com/web/fundamentals/security/csp/ )