### PR TITLE
Support SQLite as a possible database back-end

### DIFF
--- a/config/db.example.inc.php
+++ b/config/db.example.inc.php
@@ -1,8 +1,9 @@
 <?php
 # This is the database configuration of Movim
 # You need to copy an rename this file to 'db.inc.php' and complete the values
+# If using SQLite, only 'type' and 'database' are needed
 $conf = [
-    # The type can be 'pgsql' or 'mysql'
+    # The type can be 'pgsql', 'mysql', or 'sqlite'
     'type'        => 'mysql',
     # The database username
     'username'    => 'username',
@@ -10,8 +11,8 @@ $conf = [
     'password'    => 'password',
     # Where can we find the database ?
     'host'        => 'localhost',
-    # The port number, 3306 for MySQL and 5432 for PostGreSQL
+    # The port number, 3306 for MySQL and 5432 for PostgreSQL
     'port'        => 3306,
-    # The database name
+    # The database name, or for SQLite the absolute file path
     'database'    => 'movim'
 ];

--- a/database/migrations/20180716200312_set_up_sqlite.php
+++ b/database/migrations/20180716200312_set_up_sqlite.php
@@ -15,5 +15,8 @@ class SetUpSqlite extends Migration
 
     public function down()
     {
+        if ($this->schema->getConnection()->getDriverName() == 'sqlite') {
+            $this->schema->getConnection()->unprepared('PRAGMA journal_mode = delete');
+        }
     }
 }

--- a/database/migrations/20180716200312_set_up_sqlite.php
+++ b/database/migrations/20180716200312_set_up_sqlite.php
@@ -1,0 +1,19 @@
+<?php
+
+use Movim\Migration;
+use Illuminate\Database\Schema\Blueprint;
+
+class AddIndexesPresencesPostsMessagesTables extends Migration
+{
+    public function up()
+    {
+        // ensure SQLite databases use write-ahead log mode to improve concurrency
+        if ($this->schema->getConnection()->getDriverName() == 'sqlite') {
+            $this->schema->getConnection()->unprepared('PRAGMA journal_mode = wal');
+        }
+    }
+
+    public function down()
+    {
+    }
+}

--- a/database/migrations/20180716200312_set_up_sqlite.php
+++ b/database/migrations/20180716200312_set_up_sqlite.php
@@ -3,7 +3,7 @@
 use Movim\Migration;
 use Illuminate\Database\Schema\Blueprint;
 
-class AddIndexesPresencesPostsMessagesTables extends Migration
+class SetUpSqlite extends Migration
 {
     public function up()
     {

--- a/src/Movim/Bootstrap.php
+++ b/src/Movim/Bootstrap.php
@@ -200,8 +200,12 @@ class Bootstrap
 
         // if the confirgured database is SQLite, turn on foreign key constraints and set a long busy-timeout
         if (Capsule::connection() instanceof \Illuminate\Database\SQLiteConnection) {
-            Capsule::statement("PRAGMA foreign_keys = on");
-            Capsule::statement("PRAGMA busy_timeout = ". 30 * 1000); // milliseconds
+            try {
+                Capsule::statement("PRAGMA foreign_keys = on");
+                Capsule::statement("PRAGMA busy_timeout = ". 30 * 1000); // milliseconds
+            } catch (\Illuminate\Database\QueryException $e) {
+                // database does not exist yet; do nothing
+            }
         }
     }
 

--- a/src/Movim/Bootstrap.php
+++ b/src/Movim/Bootstrap.php
@@ -197,6 +197,12 @@ class Bootstrap
 
         $capsule->bootEloquent();
         $capsule->setAsGlobal();
+
+        // if the confirgured database is SQLite, turn on foreign key constraints and set a long busy-timeout
+        if (DB::connection() instanceof \Illuminate\Database\SQLiteConnection) {
+            DB::statement("PRAGMA foreign_keys = on");
+            DB::statement("PRAGMA busy_timeout = ". 30 * 1000); // milliseconds
+        }
     }
 
     private function loadCommonLibraries()

--- a/src/Movim/Bootstrap.php
+++ b/src/Movim/Bootstrap.php
@@ -199,9 +199,9 @@ class Bootstrap
         $capsule->setAsGlobal();
 
         // if the confirgured database is SQLite, turn on foreign key constraints and set a long busy-timeout
-        if (DB::connection() instanceof \Illuminate\Database\SQLiteConnection) {
-            DB::statement("PRAGMA foreign_keys = on");
-            DB::statement("PRAGMA busy_timeout = ". 30 * 1000); // milliseconds
+        if (Capsule::connection() instanceof \Illuminate\Database\SQLiteConnection) {
+            Capsule::statement("PRAGMA foreign_keys = on");
+            Capsule::statement("PRAGMA busy_timeout = ". 30 * 1000); // milliseconds
         }
     }
 

--- a/src/Movim/Bootstrap.php
+++ b/src/Movim/Bootstrap.php
@@ -201,8 +201,8 @@ class Bootstrap
         // if the confirgured database is SQLite, turn on foreign key constraints and set a long busy-timeout
         if (Capsule::connection() instanceof \Illuminate\Database\SQLiteConnection) {
             try {
-                Capsule::statement("PRAGMA foreign_keys = on");
-                Capsule::statement("PRAGMA busy_timeout = ". 30 * 1000); // milliseconds
+                Capsule::statement('PRAGMA foreign_keys = on');
+                Capsule::statement('PRAGMA busy_timeout = ' . (30 * 1000)); // milliseconds
             } catch (\Illuminate\Database\QueryException $e) {
                 // database does not exist yet; do nothing
             }

--- a/src/Movim/Bootstrap.php
+++ b/src/Movim/Bootstrap.php
@@ -198,7 +198,7 @@ class Bootstrap
         $capsule->bootEloquent();
         $capsule->setAsGlobal();
 
-        // if the confirgured database is SQLite, turn on foreign key constraints and set a long busy-timeout
+        // if the configured database is SQLite, turn on foreign key constraints and set a long busy-timeout
         if (Capsule::connection() instanceof \Illuminate\Database\SQLiteConnection) {
             try {
                 Capsule::statement('PRAGMA foreign_keys = on');

--- a/src/Movim/Migration.php
+++ b/src/Movim/Migration.php
@@ -23,15 +23,25 @@ class Migration extends AbstractMigration
 
     public function enableForeignKeyCheck()
     {
-        if ($this->schema->getConnection()->getDriverName() == 'mysql') {
-            $this->schema->getConnection()->unprepared('SET foreign_key_checks = 1');
+        switch ($this->schema->getConnection()->getDriverName()) {
+            case 'mysql':
+                $this->schema->getConnection()->unprepared('SET foreign_key_checks = 1');
+                break;
+            case 'sqlite':
+                $this->schema->getConnection()->unprepared('PRAGMA foreign_keys = on');
+                break;
         }
     }
 
     public function disableForeignKeyCheck()
     {
-        if ($this->schema->getConnection()->getDriverName() == 'mysql') {
-            $this->schema->getConnection()->unprepared('SET foreign_key_checks = 0');
+        switch ($this->schema->getConnection()->getDriverName()) {
+            case 'mysql':
+                $this->schema->getConnection()->unprepared('SET foreign_key_checks = 0');
+                break;
+            case 'sqlite':
+                $this->schema->getConnection()->unprepared('PRAGMA foreign_keys = off');
+                break;
         }
     }
 }


### PR DESCRIPTION
Required changes are pretty minor. I'm not sure if turning off foreign key constraints during the migrations where it's required for MySQL is also required for SQLite (Phinx is probably turning them off behind the scenes anyway), but it's harmless to do so.