### PR TITLE
Improve configuration handling

### DIFF
--- a/src/Movim/Bootstrap.php
+++ b/src/Movim/Bootstrap.php
@@ -194,12 +194,12 @@ class Bootstrap
     {
         $capsule = new Capsule;
         $capsule->addConnection([
-          'driver' => \DB_TYPE,
-          'host' => \DB_HOST,
-          'port' => \DB_PORT,
-          'database' => \DB_DATABASE,
-          'username' => \DB_USERNAME,
-          'password' => \DB_PASSWORD,
+          'driver' => DB_TYPE,
+          'host' => DB_HOST,
+          'port' => DB_PORT,
+          'database' => DB_DATABASE,
+          'username' => DB_USERNAME,
+          'password' => DB_PASSWORD,
           'charset' => 'utf8',
           'collation' => 'utf8_unicode_ci',
         ]);

--- a/src/Movim/Bootstrap.php
+++ b/src/Movim/Bootstrap.php
@@ -102,7 +102,7 @@ class Bootstrap
         // apply the configuration atop sensible defaults
         $conf = (isset($conf) && is_array($conf)) ? $conf : [];
         $conf = array_merge([
-            'type' => 'pgsql',
+            'type' => 'undefined',
             'host' => 'localhost',
             'username' => 'movim',
             'password' => '',

--- a/src/Movim/Bootstrap.php
+++ b/src/Movim/Bootstrap.php
@@ -99,6 +99,18 @@ class Bootstrap
             throw new \Exception('Cannot find config/db.inc.php file');
         }
 
+        // apply the configuration atop sensible defaults
+        $conf = (isset($conf) && is_array($conf)) ? $conf : [];
+        $conf = array_merge([
+            'type' => 'pgsql',
+            'host' => 'localhost',
+            'username' => 'movim',
+            'password' => '',
+            'port' => null,
+            'database' => 'movim'
+        ], $conf);
+        $conf['port'] = $conf['port'] ?? (($conf['type'] == 'mysql') ? 3306 : 5432);
+
         if (isset($_SERVER['HTTP_HOST'])) {
             define('BASE_HOST',     $_SERVER['HTTP_HOST']);
         }

--- a/src/Movim/Bootstrap.php
+++ b/src/Movim/Bootstrap.php
@@ -107,9 +107,12 @@ class Bootstrap
             'username' => 'movim',
             'password' => '',
             'port' => null,
-            'database' => 'movim'
+            'database' => null
         ], $conf);
+        // supply a default port suitable for either PostgreSQL or MySQL/MariaDB
         $conf['port'] = $conf['port'] ?? (($conf['type'] == 'mysql') ? 3306 : 5432);
+        // supply a default database name (or file path for SQLite)
+        $conf['database'] = $conf['database'] ?? (($conf['type'] == 'sqlite') ? DOCUMENT_ROOT . '/db-storage/movim.sqlite' : 'movim');
 
         if (isset($_SERVER['HTTP_HOST'])) {
             define('BASE_HOST',     $_SERVER['HTTP_HOST']);

--- a/src/Movim/Bootstrap.php
+++ b/src/Movim/Bootstrap.php
@@ -177,20 +177,14 @@ class Bootstrap
 
     private function loadCapsule()
     {
-        if (file_exists(DOCUMENT_ROOT.'/config/db.inc.php')) {
-            require DOCUMENT_ROOT.'/config/db.inc.php';
-        } else {
-            throw new \Exception('Cannot find config/db.inc.php file');
-        }
-
         $capsule = new Capsule;
         $capsule->addConnection([
-          'driver' => $conf['type'],
-          'host' => $conf['host'],
-          'port' => $conf['port'],
-          'database' => $conf['database'],
-          'username' => $conf['username'],
-          'password' => $conf['password'],
+          'driver' => \DB_TYPE,
+          'host' => \DB_HOST,
+          'port' => \DB_PORT,
+          'database' => \DB_DATABASE,
+          'username' => \DB_USERNAME,
+          'password' => \DB_PASSWORD,
           'charset' => 'utf8',
           'collation' => 'utf8_unicode_ci',
         ]);


### PR DESCRIPTION
These changes prevent Movim from failing awkwardly when supplied an incomplete configuration file, by simply providing a default configuration that the user's configuration overrides. The defaults provide an invalid database type, so the configuration file must minimally provide that much.