### PR TITLE
Fix title-case capitalization of non-ASCII avatar placeholders

### DIFF
--- a/app/helpers/StringHelper.php
+++ b/app/helpers/StringHelper.php
@@ -347,7 +347,7 @@ function invertSign($num)
 function firstLetterCapitalize($string, $firstOnly = false)
 {
     $size = ($firstOnly) ? 1 : 2;
-    return ucfirst(strtolower(mb_substr($string, 0, $size)));
+    return mb_convert_case(mb_substr($string, 0, $size), MB_CASE_TITLE);
 }
 
 /** Return a clean string that can be used for HTML ids


### PR DESCRIPTION
Before:

![image](https://user-images.githubusercontent.com/89590/43008031-fd3b4da6-8c07-11e8-9d3f-d7cafb1e8d66.png)

After:

![image](https://user-images.githubusercontent.com/89590/43008085-1f88a00c-8c08-11e8-8ee3-dc6c64c65e97.png)
