### PR TITLE
Use new, safe Electron API

### DIFF
--- a/app/assets/js/movim_electron.js
+++ b/app/assets/js/movim_electron.js
@@ -1,13 +1,12 @@
 /**
  * @brief Open the URLs in the default browser
  */
-if (typeof require !== 'undefined') {
+if (typeof window.electron !== 'undefined') {
     document.addEventListener('click', function(event) {
         if (event.target.target == '_blank'
         || (event.target.hostname != null && event.target.hostname != BASE_HOST)) {
             event.preventDefault();
-            var shell = require('electron').shell;
-            shell.openExternal(event.target.href);
+            window.electron.openExternal(event.target.href);
         }
     });
 }

--- a/app/widgets/Notification/notification.js
+++ b/app/widgets/Notification/notification.js
@@ -11,7 +11,6 @@ var Notification = {
     document_title : document.title,
     notifs_key : '',
     favicon : null,
-    electron : null,
 
     inhibit : function(sec) {
         Notification.inhibed = true;
@@ -72,8 +71,8 @@ var Notification = {
             if (Notification.favicon != null)
                 Notification.favicon.badge(0);
 
-            if (Notification.electron != null)
-                Notification.electron.notification(false);
+            if (typeof window.electron !== 'undefined')
+                window.electron.notification(false);
         } else {
             document.title =
                 '('
@@ -86,8 +85,8 @@ var Notification = {
             if (Notification.favicon != null)
                 Notification.favicon.badge(Notification.tab_counter1 + Notification.tab_counter2);
 
-            if (Notification.electron != null)
-                Notification.electron.notification(Notification.tab_counter1 + Notification.tab_counter2);
+            if (typeof window.electron !== 'undefined')
+                window.electron.notification(Notification.tab_counter1 + Notification.tab_counter2);
         }
     },
     current : function(key) {
@@ -171,11 +170,6 @@ if (typeof MovimWebsocket != 'undefined') {
                 fontStyle: 'normal',
                 bgColor: '#FF5722'
             });
-        }
-
-        if (typeof require !== 'undefined') {
-            var remote = require('electron').remote;
-            Notification.electron = remote.getCurrentWindow();
         }
 
         Notification.document_title = Notification.document_title_init;


### PR DESCRIPTION
Once movim/movim_electron#17 lands, Movim should use new API exposed by Electron app that doesn't rely on giving full access to the user's machine to some code loaded from the Internet ;)

It's not very urgent though, as the patch for Electron app features a shim that allows older pods to still fully function safely.