### PR TITLE
Fix notification suppression when the window is out of focus on Chromium

### DIFF
--- a/app/widgets/Notification/notification.js
+++ b/app/widgets/Notification/notification.js
@@ -177,12 +177,12 @@ if (typeof MovimWebsocket != 'undefined') {
         Notification_ajaxGet();
         Notification.current(Notification.notifs_key);
 
-        document.addEventListener('blur', function() {
+        window.addEventListener('blur', function() {
             Notification.focused = false;
             Notification_ajaxCurrent('blurred');
         });
 
-        document.addEventListener('focus', function() {
+        window.addEventListener('focus', function() {
             Notification.focused = true;
             Notification.current(Notification.notifs_key);
             Notification_ajaxClear(Notification.notifs_key);


### PR DESCRIPTION
According to specification, blur and focus events are called on window object.
Only Firefox (and maybe IE?) fires them also on document.

This fixes also the Electron client.