### PR TITLE
Fix all messages being marked as edited and quoted on SQLite

### DIFF
--- a/app/Message.php
+++ b/app/Message.php
@@ -16,6 +16,12 @@ class Message extends Model
         'type'    => 'chat'
     ];
 
+    protected $casts = [
+        'edited'   => 'boolean',
+        'quoted'   => 'boolean',
+        'markable' => 'boolean'
+    ];
+
     public function save(array $options = [])
     {
         try {


### PR DESCRIPTION
For some reason, when using SQLite, those values reach JS land as string.
In JavaScript, "0" is a truthy value, so we need a conversion.