### PR TITLE
Fix disappearing contact entries after being renamed by another client.

### DIFF
--- a/lib/moxl/src/Moxl/Xec/Payload/Roster.php
+++ b/lib/moxl/src/Moxl/Xec/Payload/Roster.php
@@ -17,7 +17,7 @@ class Roster extends Payload
             if ($contact) $contact->delete();
 
             if ((string)$stanza->item->attributes()->subscription != 'remove') {
-                $roster = DBRoster::firstOrNew(['jid' => $jid]);
+                $roster = DBRoster::firstOrNew(['jid' => $jid, 'session_id' => DBUser::me()->session->id]);
                 $roster->set($stanza->item);
                 $roster->save();
             }


### PR DESCRIPTION
This actually modified a cached roster entry of another random user that
happened to have the same JID in their roster.

PS. I wonder if there may be other places where similar bug happens... :P