### PR TITLE
Respect <fin complete="true"> attribute on MAM results.

### DIFF
--- a/lib/moxl/src/Moxl/Xec/Action/MAM/Get.php
+++ b/lib/moxl/src/Moxl/Xec/Action/MAM/Get.php
@@ -49,9 +49,9 @@ class Get extends Action
         $this->deliver();
 
         if(isset($stanza->fin)
+        && (!isset($stanza->fin->attributes()->complete) || $stanza->fin->attributes()->complete != 'true')
         && isset($stanza->fin->set) && $stanza->fin->set->attributes()->xmlns == 'http://jabber.org/protocol/rsm'
-        && isset($stanza->fin->set->last)
-        && (string)$stanza->fin->set->last != $this->_after) {
+        && isset($stanza->fin->set->last)) {
             $g = new Get;
             $g->setJid($this->_jid);
             $g->setTo($this->_to);


### PR DESCRIPTION
Without that, Movim requests an additional, pointless query that will return nothing.

Turned out some servers even didn't handle that properly, resulting in an infinite loop of MAM requests.

BTW. Is this a better way to deal with boolean XML attributes?