### PR TITLE
Fix MUC joining when returned presence doesn't contain the same ID

### DIFF
--- a/lib/moxl/src/Moxl/Xec/Action/Presence/Muc.php
+++ b/lib/moxl/src/Moxl/Xec/Action/Presence/Muc.php
@@ -29,7 +29,7 @@ class Muc extends Action
         }
 
         // Save the state in the session to handle the callback later
-        $session->set($this->_to . '/' .$this->_nickname, true);
+        $session->set($this->_to . '/' .$this->_nickname, $session->get('id'));
 
         Presence::muc($this->_to, $this->_nickname, $this->_mam);
     }


### PR DESCRIPTION
It could happen for plenty of reasons, the main one being an other
resource already connected to that MUC under the same nick.

Fixes #693