### PR TITLE
Fix text representation of replaced emoji.

### DIFF
--- a/src/Movim/Emoji.php
+++ b/src/Movim/Emoji.php
@@ -79,7 +79,8 @@ class Emoji
             $dom = new \DOMDocument('1.0', 'UTF-8');
             $dom->appendChild($img = $dom->createElement('img'));
             $img->setAttribute('class', 'emoji');
-            $img->setAttribute('alt', $this->_emoji[$astext]);
+            $img->setAttribute('alt', $matches[0]);
+            $img->setAttribute('title', $this->_emoji[$astext]);
             $img->setAttribute('src', BASE_URI . 'themes/' .
                 \App\Configuration::get()->theme .
                 '/img/emojis/svg/' . $astext . '.svg');


### PR DESCRIPTION
This makes it so that…
…with images turned off or unavailable, the character is displayed unchanged,
…when graphics are available, the text on mouse hover explains the emoji,
…when copy and pasting messages, the emoji character is copied verbatim.