### PR TITLE
Add name an description to composer.json.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,4 +1,6 @@
 {
+    "name": "movim/movim",
+    "description": "Decentralized social platform based on XMPP",
     "autoload": {
         "psr-0": {
             "Movim\\": "src/"


### PR DESCRIPTION
From Debian work, where the dh_phpcomposertoolchain requires these fields.