### PR TITLE
Check for the correct XEP-0166 feature

### DIFF
--- a/app/Capability.php
+++ b/app/Capability.php
@@ -71,7 +71,7 @@ class Capability extends Model
 
     public function isJingle()
     {
-        return (in_array('http://jabber.org/protocol/jingle', $this->getFeaturesAttribute()));
+        return (in_array('urn:xmpp:jingle:1', $this->getFeaturesAttribute()));
     }
 
     public function isMAM()


### PR DESCRIPTION
This allows interoperability with clients which respect the
specification and only expose the 'urn:xmpp:jingle:1' feature.

In the future, advertisement of the bogus feature should be removed,
but it is kept for compatibility with existing Movim for now.