### PR TITLE
Make public URL and WS port configurable from distribution environment file

### DIFF
--- a/etc/systemd/system/movim.service
+++ b/etc/systemd/system/movim.service
@@ -5,7 +5,10 @@ After=apache2.service network.target local-fs.target
 [Service]
 User=www-data
 Type=simple
-ExecStart=/usr/bin/php daemon.php start --url=https://localhost/movim/ --port=8080
+Environment=PUBLIC_URL=https://localhost/movim/
+Environment=WS_PORT=8080
+EnvironmentFile=-/etc/default/movim
+ExecStart=/usr/bin/php daemon.php start --url=${PUBLIC_URL} --port=${WS_PORT}
 WorkingDirectory=/usr/share/movim/
 StandardOutput=syslog
 SyslogIdentifier=movim


### PR DESCRIPTION
This is needed so to change the public URL (and protocol used to access movim) the systemd unit does not have to be changed. In Debian, we will make this configurable through debconf questions.