### PR TITLE
Fix migration for SQLite.

### DIFF
--- a/database/migrations/20180515205626_change_messages_primary_key.php
+++ b/database/migrations/20180515205626_change_messages_primary_key.php
@@ -8,7 +8,10 @@ class ChangeMessagesPrimaryKey extends Migration
     public function up()
     {
         $this->schema->table('messages', function(Blueprint $table) {
-            $table->dropForeign(['user_id']);
+            if ($this->schema->getConnection()->getDriverName() !== 'sqlite') {
+                $table->dropForeign(['user_id']);
+            }
+
             $table->dropPrimary('messages_pkey');
             $table->primary(['user_id', 'jidfrom', 'id']);
             $table->foreign('user_id')
@@ -20,7 +23,10 @@ class ChangeMessagesPrimaryKey extends Migration
     public function down()
     {
         $this->schema->table('messages', function(Blueprint $table) {
-            $table->dropForeign(['user_id']);
+            if ($this->schema->getConnection()->getDriverName() !== 'sqlite') {
+                $table->dropForeign(['user_id']);
+            }
+
             $table->dropPrimary('messages_pkey');
             $table->primary(['user_id', 'id']);
             $table->foreign('user_id')


### PR DESCRIPTION
SQLite does not support dropping foreign keys. However, it will cleanly replace the foreign key later in the migration if ignored.