### PR TITLE
Handle early exceptions

### DIFF
--- a/src/Movim/Bootstrap.php
+++ b/src/Movim/Bootstrap.php
@@ -314,7 +314,7 @@ class Bootstrap
     {
         $this->systemErrorHandler(
             E_ERROR,
-            truncate($exception->getMessage(), 400),
+            function_exists('truncate') ? truncate($exception->getMessage(), 400) : $exception->getMessage(),
             $exception->getFile(),
             $exception->getLine()
         );


### PR DESCRIPTION
If an exception is thrown before $this->loadHelpers() was called, the exception handler fails because truncate() is not yet defined. Problem reported by @Natureshadow.