### PR TITLE
[WIP] Make Movim a Progressive Web App

### DIFF
--- a/app/views/page.tpl
+++ b/app/views/page.tpl
@@ -12,6 +12,10 @@
         <link rel="icon" type="image/png" href="<?php $this->linkFile('img/app/48.png');?>" sizes="48x48">
         <link rel="icon" type="image/png" href="<?php $this->linkFile('img/app/96.png');?>" sizes="96x96">
         <link rel="icon" type="image/png" href="<?php $this->linkFile('img/app/128.png');?>" sizes="128x128">
+        <link rel="apple-touch-icon" href="<?php $this->linkFile('img/app/48.png'); ?>">
+        <link rel="apple-touch-icon" href="<?php $this->linkFile('img/app/96.png'); ?>" sizes="96x96">
+        <link rel="apple-touch-icon" href="<?php $this->linkFile('img/app/128.png'); ?>" sizes="128x128">
+        <link rel="apple-touch-icon" href="<?php $this->linkFile('img/app/512.png'); ?>" sizes="512x512">
         <script src="<?php echo BASE_URI; ?>scripts/favico.js"></script>
         <script src="<?php echo
             \Movim\Route::urlize('system') .


### PR DESCRIPTION
From the user point of a view a progressive web app is a web page that you can "install" on your mobile (and later on your PC)

Making Movim a PWA will allow anyone to install it easily on its smartphone. Full PWA has push notifications and offline capabilities

This PR fixes  #639

Todo:

- [x] Make movim installable on smartphones
- [ ] Add service worker to allow installation from Chrome on Smartphone
- [ ] Proxify images and other contents to avoid non-https content served from Movim (this breaks the PWA experience by opening the app in browser)
- [ ] Add push notifications
- [ ] Add some offline capabilities 