### PR TITLE
Support autojoin="true" in MUC bookmarks.

### DIFF
--- a/lib/moxl/src/Moxl/Xec/Action/Bookmark/Get.php
+++ b/lib/moxl/src/Moxl/Xec/Action/Bookmark/Get.php
@@ -35,7 +35,7 @@ class Get extends Action
             $conference->conference     = (string)$c->attributes()->jid;
             $conference->name           = (string)$c->attributes()->name;
             $conference->nick           = (string)$c->nick;
-            $conference->autojoin       = (boolean)$c->attributes()->autojoin;
+            $conference->autojoin       = filter_var($c->attributes()->autojoin, FILTER_VALIDATE_BOOLEAN);
 
             $conference->save();
         }


### PR DESCRIPTION
Fix #807.

Solution found here: https://stackoverflow.com/questions/4775294/parsing-a-string-into-a-boolean-value-in-php#answer-10645030