### PR TITLE
Restart movim daemon after failure.

### DIFF
--- a/etc/systemd/system/movim.service
+++ b/etc/systemd/system/movim.service
@@ -13,6 +13,8 @@ WorkingDirectory=/usr/share/movim/
 StandardOutput=syslog
 SyslogIdentifier=movim
 PIDFile=/run/movim.pid
+Restart=on-failure
+RestartSec=10
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
The movim daemon reacts indignant to various situations, like the database backend being restarted in the wrong moment, and then exits. systemd can try to restart it automatically in that case.