### PR TITLE
Work around broken modifier parsing in raintpl3. Fixes #825.

### DIFF
--- a/app/helpers/StringHelper.php
+++ b/app/helpers/StringHelper.php
@@ -385,3 +385,10 @@ function urilize($path, bool $noTime = false): string
 
     return BASE_URI . $path . '?t=' . filemtime(DOCUMENT_ROOT . '/' . $path);
 }
+
+/**
+ * Return a comma-separated list of joined array elements
+ */
+function implodeCsv($value) {
+    return implode(', ', $value);
+}

--- a/app/widgets/Chat/_chat_reactions.tpl
+++ b/app/widgets/Chat/_chat_reactions.tpl
@@ -1,5 +1,5 @@
 {loop="$reactions"}
-    <li title="{$value|implode:', '}"
+    <li title="{$value|implodeCsv}"
         {if="in_array($me, $value)"}class="reacted"{/if}
         onclick="Chat_ajaxHttpSendReaction('{$message->mid}', '{$key}')">
         {autoescape="off"}


### PR DESCRIPTION
The modifier parser in raintpl is broken when the string argument
contains other characters than valid PHP odemtofoers, like comma and
space. Thus, we wrap the generation of the comaa-separated list in a
helper function that can safely be called in a template.