### PR TITLE
Possibly fix the Emoji substitution errors

### DIFF
--- a/src/Movim/Emoji.php
+++ b/src/Movim/Emoji.php
@@ -1,7 +1,7 @@
 <?php
 /*-
- * Copyright © 2018
- * mirabilos <thorsten.glaser@teckids.org>
+ * Copyright © 2018, 2019
+ *	mirabilos <thorsten.glaser@teckids.org>
  *
  * Provided that these terms and disclaimer and all copyright notices
  * are retained or reproduced in an accompanying document, permission
@@ -66,10 +66,9 @@ class Emoji
     public function replace($string, bool $noTitle = false): string
     {
         $this->_string = $string;
+        $this->_lastEmoji = null;
 
         return preg_replace_callback($this->_regex, function ($matches) use ($noTitle) {
-            $this->_lastEmoji = $matches[0];
-
             $astext = implode(
                 '-',
                 array_map(
@@ -82,6 +81,7 @@ class Emoji
                 return $matches[0];
             }
 
+            $this->_lastEmoji = $matches[0];
             $this->_lastEmojiURL = BASE_URI . 'theme/img/emojis/svg/' . $astext . '.svg';
 
             $dom = new \DOMDocument('1.0', 'UTF-8');

--- a/src/Movim/Emoji/compile-file-list.sh
+++ b/src/Movim/Emoji/compile-file-list.sh
@@ -21,7 +21,7 @@
 # Needs the Debian packages mksh and unicode-data installed.
 
 cd "$(dirname "$0")"
-srcpath=../../../theme/img/emojis/svg
+srcpath=../../../public/theme/img/emojis/svg
 
 cd "$srcpath"
 set -A files -- *.svg

--- a/src/Movim/Emoji/php
+++ b/src/Movim/Emoji/php
@@ -1,1 +1,0 @@
-😁 replace-test.php

--- a/src/Movim/Emoji/replace-test.php
+++ b/src/Movim/Emoji/replace-test.php
@@ -1,19 +1,7 @@
 <?php
 
-namespace App;
-
 define('BASE_URI', '(base)');
 mb_internal_encoding("UTF-8");
-
-class Configuration
-{
-    public $theme = '(theme)';
-
-    public static function findOrNew()
-    {
-        return new Configuration;
-    }
-}
 
 require_once '../Emoji.php';
 

--- a/src/Movim/Emoji/test-all-images.sh
+++ b/src/Movim/Emoji/test-all-images.sh
@@ -1,6 +1,6 @@
 #!/bin/mksh
 #-
-# Copyright © 2018
+# Copyright © 2018, 2019
 #	mirabilos <thorsten.glaser@teckids.org>
 #
 # Provided that these terms and disclaimer and all copyright notices
@@ -23,15 +23,39 @@ srcpath=../../../public/theme/img/emojis/svg
 saveIFS=$IFS
 
 cd "$srcpath"
+allfiles=1
 set -A files -- *.svg
 cd "$OLDPWD"
 
 if [[ -n $1 ]]; then
+    allfiles=0
     set -A files -- "$@"
     print -ru2 -- "W: only testing $# files from command line"
 fi
 
-for f in "${files[@]}"; do
+for f in "${files[@]}" -; do
+    if [[ $f = - ]]; then
+        if (( !allfiles )); then
+            # skip if only testing files from command line
+            print -r -- 'print "-\n~\n";'
+            break
+        fi
+        cat <<\EOF
+            print "-\n";
+            no warnings 'nonchar';
+            my $i = 0x0020 - 1;
+            while (++$i <= 0x10FFFF) {
+                # skip (relevant) non-characters
+                next if ($i & 0xFFFE) == 0xFFFE;
+                # skip surrogates
+                $i = 0xE000 if $i == 0xD800;
+                # output characters not used by the SVGs
+                printf("<%04X>=%c\n", $i, $i) unless exists($h{$i});
+            }
+            print "~\n";
+EOF
+        break
+    fi
     x=${f%.svg}
     IFS=-
     set -A y -- $x
@@ -40,22 +64,60 @@ for f in "${files[@]}"; do
     for z in "${y[@]}"; do
         s+="\\x{$z}"
     done
-    print -r -- "$s\\n\";"
+    print -r -- "$s\\n\"; \$h{0x${y[0]}}=1;"
 done | perl -C7 | php replace-test.php |&
 n=-1
 rv=0
 match=0
 mis=0
+cpnt=0
+cnot=0
+function out {
+    print -ru2 -- "I: $match/${#files[*]} matched, $mis mismatched"
+    (( allfiles )) && print -ru2 -- "I: $cnot/$cpnt codepoints (expectedly) did not match, $((cpnt-cnot)) mistakenly matched"
+    (( rv & 1 )) && print -ru2 -- "E: some files did not match"
+    (( rv & 2 )) && print -ru2 -- "E: incomplete processing of first half"
+    (( rv & 4 )) && print -ru2 -- "E: some codepoints mistakenly matched"
+    (( rv & 8 )) && print -ru2 -- "E: incomplete processing of second half"
+    (( rv )) || if (( allfiles )); then
+        print -ru2 -- "I: all files matched, all others didn’t ⇒ all OK"
+    else
+        print -ru2 -- "I: all files to be tested matched"
+    fi
+    exit $rv
+}
+print -nu2 -- "N: processing SVGs…\\r"
 while IFS= read -pr line; do
+    [[ $line = '-' ]] && break
     if [[ $line = '<img'*"/svg/${files[++n]}\""*\> ]]; then
         let ++match
         continue
     fi
     print -ru2 -- "W: file ${files[n]} not matched"
-    [[ -n $1 ]] && print -ru2 -- "N: line: $line"
-    rv=1
+    (( allfiles )) || print -ru2 -- "N: line: $line"
+    (( rv |= 1 ))
     let ++mis
 done
-(( rv )) || print -ru2 -- "I: all files matched"
-print -ru2 -- "I: $match/${#files[*]} matched, $mis mismatched"
-exit $rv
+if [[ $line != '-' ]]; then
+    (( rv |= 2 ))
+    out
+fi
+i=0
+while IFS= read -pr line; do
+    if [[ $line = '~' ]]; then
+        read -pr x && print -ru2 -- "E: data after end of input: $x"
+        break
+    fi
+    let ++cpnt
+    (( i++ & 4095 )) || print -nu2 -- "N: processing ${line%%=*}…\\r"
+    if [[ $line = *'<img'* ]]; then
+        print -ru2 -- "W: mistaken match for codepoint $line"
+    else
+        let ++cnot
+    fi
+done
+if [[ $line != '~' ]]; then
+    (( rv |= 8 ))
+    out
+fi
+out

--- a/src/Movim/Emoji/test-all-images.sh
+++ b/src/Movim/Emoji/test-all-images.sh
@@ -19,7 +19,7 @@
 # of said person’s immediate fault when using the work as intended.
 
 cd "$(dirname "$0")"
-srcpath=../../../theme/img/emojis/svg
+srcpath=../../../public/theme/img/emojis/svg
 saveIFS=$IFS
 
 cd "$srcpath"


### PR DESCRIPTION
This is the likely fix for https://github.com/movim/movim/issues/835 plus a couple of code cleanup activities in this forgotten area of the code, and it extends the testsuite for the replacement code to validate that all *other* codepoints pass through unchanged.

Pending testing…