### PR TITLE
Fix /code handling in UI.

### DIFF
--- a/app/widgets/Chat/chat.js
+++ b/app/widgets/Chat/chat.js
@@ -477,7 +477,7 @@ var Chat = {
             data.body = data.body.substr(4);
         }
 
-        if (data.body.match(/^\/code/)) {
+        if (data.body.match(/^\/code\s/)) {
             p.classList.add('code');
             data.body = data.body.substr(6).trim();
         }


### PR DESCRIPTION
The detection of /code was missing a space after the "command", so /codeblubb would render as lubb in a code block with the b removed.