### PR TITLE
Make /me mesages italic again.

### DIFF
--- a/public/theme/css/listn.css
+++ b/public/theme/css/listn.css
@@ -408,6 +408,10 @@ ul li div.bubble:after {
     text-align: left;
 }
 
+ul li .quote {
+    font-style: italic;
+}
+
 ul li div.bubble:not(.sticker):not(.file):before {
     content: "";
     position: absolute;


### PR DESCRIPTION
This CSS was dropped in unrelated 854db43a913aa55819ef95d0c91c8196290ece48 for no obvious reason.