### PR TITLE
Update the DOAP file to the latest specification

### DIFF
--- a/doap.xml
+++ b/doap.xml
@@ -32,11 +32,9 @@
 
     <os>Linux</os>
 
-    <!-- TODO: Categories are URIs, find a better location for them. -->
-    <category rdf:resource="https://linkmauve.fr/ns/xmpp-doap#category-xmpp"/>
-    <category rdf:resource="https://linkmauve.fr/ns/xmpp-doap#category-jabber"/>
     <category rdf:resource="https://linkmauve.fr/ns/xmpp-doap#category-client"/>
-    <category rdf:resource="https://linkmauve.fr/ns/xmpp-doap#category-web"/>
+    <!-- TODO: Find a good set of resource URIs for this one. -->
+    <category rdf:resource="https://example.com/doap#category-web"/>
 
     <maintainer>
         <foaf:Person>
@@ -59,339 +57,333 @@
     <implements rdf:resource="https://xmpp.org/rfcs/rfc7590.html"/>
     <!-- TODO: Report a bug to support that in poezio. -->
     <!--<implements rdf:resource="https://xmpp.org/rfcs/rfc5122.html"/>-->
-
-    <xmpp:software>
-        <xmpp:Client>
-
-            <xmpp:supports>
-                <xmpp:SupportedXep>
-                    <xmpp:xep rdf:resource="https://xmpp.org/extensions/xep-0004.html"/>
-                    <xmpp:status>complete</xmpp:status>
-                    <xmpp:version>2.9</xmpp:version>
-                </xmpp:SupportedXep>
-            </xmpp:supports>
-            <xmpp:supports>
-                <xmpp:SupportedXep>
-                    <xmpp:xep rdf:resource="https://xmpp.org/extensions/xep-0012.html"/>
-                    <xmpp:status>complete</xmpp:status>
-                    <xmpp:version>2.0</xmpp:version>
-                </xmpp:SupportedXep>
-            </xmpp:supports>
-            <xmpp:supports>
-                <xmpp:SupportedXep>
-                    <xmpp:xep rdf:resource="https://xmpp.org/extensions/xep-0030.html"/>
-                    <xmpp:status>complete</xmpp:status>
-                    <xmpp:version>2.4</xmpp:version>
-                </xmpp:SupportedXep>
-            </xmpp:supports>
-            <xmpp:supports>
-                <xmpp:SupportedXep>
-                    <xmpp:xep rdf:resource="https://xmpp.org/extensions/xep-0045.html"/>
-                    <xmpp:status>partial</xmpp:status>
-                    <xmpp:version>1.27.1</xmpp:version>
-                </xmpp:SupportedXep>
-            </xmpp:supports>
-            <xmpp:supports>
-                <xmpp:SupportedXep>
-                    <xmpp:xep rdf:resource="https://xmpp.org/extensions/xep-0048.html"/>
-                    <xmpp:status>complete</xmpp:status>
-                    <xmpp:version>1.1</xmpp:version>
-                </xmpp:SupportedXep>
-            </xmpp:supports>
-            <xmpp:supports>
-                <xmpp:SupportedXep>
-                    <xmpp:xep rdf:resource="https://xmpp.org/extensions/xep-0049.html"/>
-                    <xmpp:status>complete</xmpp:status>
-                    <xmpp:version>1.2</xmpp:version>
-                </xmpp:SupportedXep>
-            </xmpp:supports>
-            <xmpp:supports>
-                <xmpp:SupportedXep>
-                    <xmpp:xep rdf:resource="https://xmpp.org/extensions/xep-0050.html"/>
-                    <xmpp:status>partial</xmpp:status>
-                    <xmpp:version>1.2.2</xmpp:version>
-                </xmpp:SupportedXep>
-            </xmpp:supports>
-            <xmpp:supports>
-                <xmpp:SupportedXep>
-                    <xmpp:xep rdf:resource="https://xmpp.org/extensions/xep-0054.html"/>
-                    <xmpp:status>complete</xmpp:status>
-                    <xmpp:version>1.2</xmpp:version>
-                    <xmpp:note>no avatar sent</xmpp:note>
-                </xmpp:SupportedXep>
-            </xmpp:supports>
-            <xmpp:supports>
-                <xmpp:SupportedXep>
-                    <xmpp:xep rdf:resource="https://xmpp.org/extensions/xep-0059.html"/>
-                    <xmpp:status>complete</xmpp:status>
-                    <xmpp:version>1.0</xmpp:version>
-                    <xmpp:note>for PEP/Pubsub retrieval and MAM</xmpp:note>
-                </xmpp:SupportedXep>
-            </xmpp:supports>
-            <xmpp:supports>
-                <xmpp:SupportedXep>
-                    <xmpp:xep rdf:resource="https://xmpp.org/extensions/xep-0060.html"/>
-                    <xmpp:status>partial</xmpp:status>
-                    <xmpp:version>1.15.7</xmpp:version>
-                </xmpp:SupportedXep>
-            </xmpp:supports>
-            <xmpp:supports>
-                <xmpp:SupportedXep>
-                    <xmpp:xep rdf:resource="https://xmpp.org/extensions/xep-0070.html"/>
-                    <xmpp:status>complete</xmpp:status>
-                    <xmpp:version>1.0.1</xmpp:version>
-                </xmpp:SupportedXep>
-            </xmpp:supports>
-            <xmpp:supports>
-                <xmpp:SupportedXep>
-                    <xmpp:xep rdf:resource="https://xmpp.org/extensions/xep-0071.html"/>
-                    <xmpp:status>partial</xmpp:status>
-                    <xmpp:version>1.5.4</xmpp:version>
-                </xmpp:SupportedXep>
-            </xmpp:supports>
-            <xmpp:supports>
-                <xmpp:SupportedXep>
-                    <xmpp:xep rdf:resource="https://xmpp.org/extensions/xep-0077.html"/>
-                    <xmpp:status>partial</xmpp:status>
-                    <xmpp:version>2.4</xmpp:version>
-                </xmpp:SupportedXep>
-            </xmpp:supports>
-            <xmpp:supports>
-                <xmpp:SupportedXep>
-                    <xmpp:xep rdf:resource="https://xmpp.org/extensions/xep-0084.html"/>
-                    <xmpp:status>complete</xmpp:status>
-                    <xmpp:version>1.1.2</xmpp:version>
-                </xmpp:SupportedXep>
-            </xmpp:supports>
-            <xmpp:supports>
-                <xmpp:SupportedXep>
-                    <xmpp:xep rdf:resource="https://xmpp.org/extensions/xep-0085.html"/>
-                    <xmpp:status>partial</xmpp:status>
-                    <xmpp:version>2.1</xmpp:version>
-                    <xmpp:note>also displayed in group chat</xmpp:note>
-                </xmpp:SupportedXep>
-            </xmpp:supports>
-            <xmpp:supports>
-                <xmpp:SupportedXep>
-                    <xmpp:xep rdf:resource="https://xmpp.org/extensions/xep-0092.html"/>
-                    <xmpp:status>complete</xmpp:status>
-                    <xmpp:version>1.1</xmpp:version>
-                    <xmpp:note>send only</xmpp:note>
-                </xmpp:SupportedXep>
-            </xmpp:supports>
-            <xmpp:supports>
-                <xmpp:SupportedXep>
-                    <xmpp:xep rdf:resource="https://xmpp.org/extensions/xep-0100.html"/>
-                    <xmpp:status>complete</xmpp:status>
-                    <xmpp:version>1.0</xmpp:version>
-                </xmpp:SupportedXep>
-            </xmpp:supports>
-            <xmpp:supports>
-                <xmpp:SupportedXep>
-                    <xmpp:xep rdf:resource="https://xmpp.org/extensions/xep-0107.html"/>
-                    <xmpp:status>partial</xmpp:status>
-                    <xmpp:version>1.2</xmpp:version>
-                    <xmpp:note>read only</xmpp:note>
-                </xmpp:SupportedXep>
-            </xmpp:supports>
-            <xmpp:supports>
-                <xmpp:SupportedXep>
-                    <xmpp:xep rdf:resource="https://xmpp.org/extensions/xep-0108.html"/>
-                    <xmpp:status>partial</xmpp:status>
-                    <xmpp:version>1.3</xmpp:version>
-                    <xmpp:note>read only</xmpp:note>
-                </xmpp:SupportedXep>
-            </xmpp:supports>
-            <xmpp:supports>
-                <xmpp:SupportedXep>
-                    <xmpp:xep rdf:resource="https://xmpp.org/extensions/xep-0115.html"/>
-                    <xmpp:status>partial</xmpp:status>
-                    <xmpp:version>1.5.1</xmpp:version>
-                </xmpp:SupportedXep>
-            </xmpp:supports>
-            <xmpp:supports>
-                <xmpp:SupportedXep>
-                    <xmpp:xep rdf:resource="https://xmpp.org/extensions/xep-0118.html"/>
-                    <xmpp:status>partial</xmpp:status>
-                    <xmpp:version>1.2</xmpp:version>
-                    <xmpp:note>read only</xmpp:note>
-                </xmpp:SupportedXep>
-            </xmpp:supports>
-            <xmpp:supports>
-                <xmpp:SupportedXep>
-                    <xmpp:xep rdf:resource="https://xmpp.org/extensions/xep-0153.html"/>
-                    <xmpp:status>complete</xmpp:status>
-                    <xmpp:version>1.1</xmpp:version>
-                </xmpp:SupportedXep>
-            </xmpp:supports>
-            <xmpp:supports>
-                <xmpp:SupportedXep>
-                    <xmpp:xep rdf:resource="https://xmpp.org/extensions/xep-0157.html"/>
-                    <xmpp:status>complete</xmpp:status>
-                    <xmpp:version>1.0.1</xmpp:version>
-                </xmpp:SupportedXep>
-            </xmpp:supports>
-            <xmpp:supports>
-                <xmpp:SupportedXep>
-                    <xmpp:xep rdf:resource="https://xmpp.org/extensions/xep-0163.html"/>
-                    <xmpp:status>complete</xmpp:status>
-                    <xmpp:version>1.2.1</xmpp:version>
-                </xmpp:SupportedXep>
-            </xmpp:supports>
-            <xmpp:supports>
-                <xmpp:SupportedXep>
-                    <xmpp:xep rdf:resource="https://xmpp.org/extensions/xep-0172.html"/>
-                    <xmpp:status>complete</xmpp:status>
-                    <xmpp:version>1.1</xmpp:version>
-                    <xmpp:note>read only</xmpp:note>
-                </xmpp:SupportedXep>
-            </xmpp:supports>
-            <xmpp:supports>
-                <xmpp:SupportedXep>
-                    <xmpp:xep rdf:resource="https://xmpp.org/extensions/xep-0184.html"/>
-                    <xmpp:status>complete</xmpp:status>
-                    <xmpp:version>1.2</xmpp:version>
-                </xmpp:SupportedXep>
-            </xmpp:supports>
-            <xmpp:supports>
-                <xmpp:SupportedXep>
-                    <xmpp:xep rdf:resource="https://xmpp.org/extensions/xep-0199.html"/>
-                    <xmpp:status>complete</xmpp:status>
-                    <xmpp:version>2.0.1</xmpp:version>
-                </xmpp:SupportedXep>
-            </xmpp:supports>
-            <xmpp:supports>
-                <xmpp:SupportedXep>
-                    <xmpp:xep rdf:resource="https://xmpp.org/extensions/xep-0203.html"/>
-                    <xmpp:status>complete</xmpp:status>
-                    <xmpp:version>2.0</xmpp:version>
-                </xmpp:SupportedXep>
-            </xmpp:supports>
-            <xmpp:supports>
-                <xmpp:SupportedXep>
-                    <xmpp:xep rdf:resource="https://xmpp.org/extensions/xep-0231.html"/>
-                    <xmpp:status>partial</xmpp:status>
-                    <xmpp:version>1.0</xmpp:version>
-                    <xmpp:note>stickers feature</xmpp:note>
-                </xmpp:SupportedXep>
-            </xmpp:supports>
-            <xmpp:supports>
-                <xmpp:SupportedXep>
-                    <xmpp:xep rdf:resource="https://xmpp.org/extensions/xep-0245.html"/>
-                    <xmpp:status>complete</xmpp:status>
-                    <xmpp:version>1.0</xmpp:version>
-                </xmpp:SupportedXep>
-            </xmpp:supports>
-            <xmpp:supports>
-                <xmpp:SupportedXep>
-                    <xmpp:xep rdf:resource="https://xmpp.org/extensions/xep-0256.html"/>
-                    <xmpp:status>complete</xmpp:status>
-                    <xmpp:version>1.1</xmpp:version>
-                </xmpp:SupportedXep>
-            </xmpp:supports>
-            <xmpp:supports>
-                <xmpp:SupportedXep>
-                    <xmpp:xep rdf:resource="https://xmpp.org/extensions/xep-0277.html"/>
-                    <xmpp:status>complete</xmpp:status>
-                    <xmpp:version>0.6.3</xmpp:version>
-                </xmpp:SupportedXep>
-            </xmpp:supports>
-            <xmpp:supports>
-                <xmpp:SupportedXep>
-                    <xmpp:xep rdf:resource="https://xmpp.org/extensions/xep-0280.html"/>
-                    <xmpp:status>complete</xmpp:status>
-                    <xmpp:version>0.11.0</xmpp:version>
-                </xmpp:SupportedXep>
-            </xmpp:supports>
-            <xmpp:supports>
-                <xmpp:SupportedXep>
-                    <xmpp:xep rdf:resource="https://xmpp.org/extensions/xep-0292.html"/>
-                    <xmpp:status>complete</xmpp:status>
-                    <xmpp:version>0.10</xmpp:version>
-                </xmpp:SupportedXep>
-            </xmpp:supports>
-            <xmpp:supports>
-                <xmpp:SupportedXep>
-                    <xmpp:xep rdf:resource="https://xmpp.org/extensions/xep-0297.html"/>
-                    <xmpp:status>complete</xmpp:status>
-                    <xmpp:version>1.0</xmpp:version>
-                    <xmpp:since>0.8</xmpp:since>
-                    <xmpp:note>only used for Carbons</xmpp:note>
-                </xmpp:SupportedXep>
-            </xmpp:supports>
-            <xmpp:supports>
-                <xmpp:SupportedXep>
-                    <xmpp:xep rdf:resource="https://xmpp.org/extensions/xep-0308.html"/>
-                    <xmpp:status>complete</xmpp:status>
-                    <xmpp:version>1.0</xmpp:version>
-                </xmpp:SupportedXep>
-            </xmpp:supports>
-            <xmpp:supports>
-                <xmpp:SupportedXep>
-                    <xmpp:xep rdf:resource="https://xmpp.org/extensions/xep-0313.html"/>
-                    <xmpp:status>complete</xmpp:status>
-                    <xmpp:version>0.6.3</xmpp:version>
-                </xmpp:SupportedXep>
-            </xmpp:supports>
-            <xmpp:supports>
-                <xmpp:SupportedXep>
-                    <xmpp:xep rdf:resource="https://xmpp.org/extensions/xep-0330.html"/>
-                    <xmpp:status>complete</xmpp:status>
-                    <xmpp:version>0.1</xmpp:version>
-                </xmpp:SupportedXep>
-            </xmpp:supports>
-            <xmpp:supports>
-                <xmpp:SupportedXep>
-                    <xmpp:xep rdf:resource="https://xmpp.org/extensions/xep-0333.html"/>
-                    <xmpp:status>complete</xmpp:status>
-                    <xmpp:version>0.3</xmpp:version>
-                </xmpp:SupportedXep>
-            </xmpp:supports>
-            <xmpp:supports>
-                <xmpp:SupportedXep>
-                    <xmpp:xep rdf:resource="https://xmpp.org/extensions/xep-0334.html"/>
-                    <xmpp:status>complete</xmpp:status>
-                    <xmpp:version>0.2</xmpp:version>
-                </xmpp:SupportedXep>
-            </xmpp:supports>
-            <xmpp:supports>
-                <xmpp:SupportedXep>
-                    <xmpp:xep rdf:resource="https://xmpp.org/extensions/xep-0359.html"/>
-                    <xmpp:status>complete</xmpp:status>
-                    <xmpp:version>0.6</xmpp:version>
-                </xmpp:SupportedXep>
-            </xmpp:supports>
-            <xmpp:supports>
-                <xmpp:SupportedXep>
-                    <xmpp:xep rdf:resource="https://xmpp.org/extensions/xep-0363.html"/>
-                    <xmpp:status>complete</xmpp:status>
-                    <xmpp:version>0.9</xmpp:version>
-                </xmpp:SupportedXep>
-            </xmpp:supports>
-            <xmpp:supports>
-                <xmpp:SupportedXep>
-                    <xmpp:xep rdf:resource="https://xmpp.org/extensions/xep-0367.html"/>
-                    <xmpp:status>complete</xmpp:status>
-                    <xmpp:version>0.3</xmpp:version>
-                    <xmpp:note>for reactions</xmpp:note>
-                </xmpp:SupportedXep>
-            </xmpp:supports>
-            <xmpp:supports>
-                <xmpp:SupportedXep>
-                    <xmpp:xep rdf:resource="https://xmpp.org/extensions/xep-0372.html"/>
-                    <xmpp:status>complete</xmpp:status>
-                    <xmpp:version>0.2</xmpp:version>
-                </xmpp:SupportedXep>
-            </xmpp:supports>
-            <xmpp:supports>
-                <xmpp:SupportedXep>
-                    <xmpp:xep rdf:resource="https://xmpp.org/extensions/xep-0385.html"/>
-                    <xmpp:status>partial</xmpp:status>
-                    <xmpp:version>0.2.1</xmpp:version>
-                </xmpp:SupportedXep>
-            </xmpp:supports>
-        </xmpp:Client>
-    </xmpp:software>
+    <implements>
+        <xmpp:SupportedXep>
+            <xmpp:xep rdf:resource="https://xmpp.org/extensions/xep-0004.html"/>
+            <xmpp:status>complete</xmpp:status>
+            <xmpp:version>2.9</xmpp:version>
+        </xmpp:SupportedXep>
+    </implements>
+    <implements>
+        <xmpp:SupportedXep>
+            <xmpp:xep rdf:resource="https://xmpp.org/extensions/xep-0012.html"/>
+            <xmpp:status>complete</xmpp:status>
+            <xmpp:version>2.0</xmpp:version>
+        </xmpp:SupportedXep>
+    </implements>
+    <implements>
+        <xmpp:SupportedXep>
+            <xmpp:xep rdf:resource="https://xmpp.org/extensions/xep-0030.html"/>
+            <xmpp:status>complete</xmpp:status>
+            <xmpp:version>2.4</xmpp:version>
+        </xmpp:SupportedXep>
+    </implements>
+    <implements>
+        <xmpp:SupportedXep>
+            <xmpp:xep rdf:resource="https://xmpp.org/extensions/xep-0045.html"/>
+            <xmpp:status>partial</xmpp:status>
+            <xmpp:version>1.27.1</xmpp:version>
+        </xmpp:SupportedXep>
+    </implements>
+    <implements>
+        <xmpp:SupportedXep>
+            <xmpp:xep rdf:resource="https://xmpp.org/extensions/xep-0048.html"/>
+            <xmpp:status>complete</xmpp:status>
+            <xmpp:version>1.1</xmpp:version>
+        </xmpp:SupportedXep>
+    </implements>
+    <implements>
+        <xmpp:SupportedXep>
+            <xmpp:xep rdf:resource="https://xmpp.org/extensions/xep-0049.html"/>
+            <xmpp:status>complete</xmpp:status>
+            <xmpp:version>1.2</xmpp:version>
+        </xmpp:SupportedXep>
+    </implements>
+    <implements>
+        <xmpp:SupportedXep>
+            <xmpp:xep rdf:resource="https://xmpp.org/extensions/xep-0050.html"/>
+            <xmpp:status>partial</xmpp:status>
+            <xmpp:version>1.2.2</xmpp:version>
+        </xmpp:SupportedXep>
+    </implements>
+    <implements>
+        <xmpp:SupportedXep>
+            <xmpp:xep rdf:resource="https://xmpp.org/extensions/xep-0054.html"/>
+            <xmpp:status>complete</xmpp:status>
+            <xmpp:version>1.2</xmpp:version>
+            <xmpp:note>no avatar sent</xmpp:note>
+        </xmpp:SupportedXep>
+    </implements>
+    <implements>
+        <xmpp:SupportedXep>
+            <xmpp:xep rdf:resource="https://xmpp.org/extensions/xep-0059.html"/>
+            <xmpp:status>complete</xmpp:status>
+            <xmpp:version>1.0</xmpp:version>
+            <xmpp:note>for PEP/Pubsub retrieval and MAM</xmpp:note>
+        </xmpp:SupportedXep>
+    </implements>
+    <implements>
+        <xmpp:SupportedXep>
+            <xmpp:xep rdf:resource="https://xmpp.org/extensions/xep-0060.html"/>
+            <xmpp:status>partial</xmpp:status>
+            <xmpp:version>1.15.7</xmpp:version>
+        </xmpp:SupportedXep>
+    </implements>
+    <implements>
+        <xmpp:SupportedXep>
+            <xmpp:xep rdf:resource="https://xmpp.org/extensions/xep-0070.html"/>
+            <xmpp:status>complete</xmpp:status>
+            <xmpp:version>1.0.1</xmpp:version>
+        </xmpp:SupportedXep>
+    </implements>
+    <implements>
+        <xmpp:SupportedXep>
+            <xmpp:xep rdf:resource="https://xmpp.org/extensions/xep-0071.html"/>
+            <xmpp:status>partial</xmpp:status>
+            <xmpp:version>1.5.4</xmpp:version>
+        </xmpp:SupportedXep>
+    </implements>
+    <implements>
+        <xmpp:SupportedXep>
+            <xmpp:xep rdf:resource="https://xmpp.org/extensions/xep-0077.html"/>
+            <xmpp:status>partial</xmpp:status>
+            <xmpp:version>2.4</xmpp:version>
+        </xmpp:SupportedXep>
+    </implements>
+    <implements>
+        <xmpp:SupportedXep>
+            <xmpp:xep rdf:resource="https://xmpp.org/extensions/xep-0084.html"/>
+            <xmpp:status>complete</xmpp:status>
+            <xmpp:version>1.1.2</xmpp:version>
+        </xmpp:SupportedXep>
+    </implements>
+    <implements>
+        <xmpp:SupportedXep>
+            <xmpp:xep rdf:resource="https://xmpp.org/extensions/xep-0085.html"/>
+            <xmpp:status>partial</xmpp:status>
+            <xmpp:version>2.1</xmpp:version>
+            <xmpp:note>also displayed in group chat</xmpp:note>
+        </xmpp:SupportedXep>
+    </implements>
+    <implements>
+        <xmpp:SupportedXep>
+            <xmpp:xep rdf:resource="https://xmpp.org/extensions/xep-0092.html"/>
+            <xmpp:status>complete</xmpp:status>
+            <xmpp:version>1.1</xmpp:version>
+            <xmpp:note>send only</xmpp:note>
+        </xmpp:SupportedXep>
+    </implements>
+    <implements>
+        <xmpp:SupportedXep>
+            <xmpp:xep rdf:resource="https://xmpp.org/extensions/xep-0100.html"/>
+            <xmpp:status>complete</xmpp:status>
+            <xmpp:version>1.0</xmpp:version>
+        </xmpp:SupportedXep>
+    </implements>
+    <implements>
+        <xmpp:SupportedXep>
+            <xmpp:xep rdf:resource="https://xmpp.org/extensions/xep-0107.html"/>
+            <xmpp:status>partial</xmpp:status>
+            <xmpp:version>1.2</xmpp:version>
+            <xmpp:note>read only</xmpp:note>
+        </xmpp:SupportedXep>
+    </implements>
+    <implements>
+        <xmpp:SupportedXep>
+            <xmpp:xep rdf:resource="https://xmpp.org/extensions/xep-0108.html"/>
+            <xmpp:status>partial</xmpp:status>
+            <xmpp:version>1.3</xmpp:version>
+            <xmpp:note>read only</xmpp:note>
+        </xmpp:SupportedXep>
+    </implements>
+    <implements>
+        <xmpp:SupportedXep>
+            <xmpp:xep rdf:resource="https://xmpp.org/extensions/xep-0115.html"/>
+            <xmpp:status>partial</xmpp:status>
+            <xmpp:version>1.5.1</xmpp:version>
+        </xmpp:SupportedXep>
+    </implements>
+    <implements>
+        <xmpp:SupportedXep>
+            <xmpp:xep rdf:resource="https://xmpp.org/extensions/xep-0118.html"/>
+            <xmpp:status>partial</xmpp:status>
+            <xmpp:version>1.2</xmpp:version>
+            <xmpp:note>read only</xmpp:note>
+        </xmpp:SupportedXep>
+    </implements>
+    <implements>
+        <xmpp:SupportedXep>
+            <xmpp:xep rdf:resource="https://xmpp.org/extensions/xep-0153.html"/>
+            <xmpp:status>complete</xmpp:status>
+            <xmpp:version>1.1</xmpp:version>
+        </xmpp:SupportedXep>
+    </implements>
+    <implements>
+        <xmpp:SupportedXep>
+            <xmpp:xep rdf:resource="https://xmpp.org/extensions/xep-0157.html"/>
+            <xmpp:status>complete</xmpp:status>
+            <xmpp:version>1.0.1</xmpp:version>
+        </xmpp:SupportedXep>
+    </implements>
+    <implements>
+        <xmpp:SupportedXep>
+            <xmpp:xep rdf:resource="https://xmpp.org/extensions/xep-0163.html"/>
+            <xmpp:status>complete</xmpp:status>
+            <xmpp:version>1.2.1</xmpp:version>
+        </xmpp:SupportedXep>
+    </implements>
+    <implements>
+        <xmpp:SupportedXep>
+            <xmpp:xep rdf:resource="https://xmpp.org/extensions/xep-0172.html"/>
+            <xmpp:status>complete</xmpp:status>
+            <xmpp:version>1.1</xmpp:version>
+            <xmpp:note>read only</xmpp:note>
+        </xmpp:SupportedXep>
+    </implements>
+    <implements>
+        <xmpp:SupportedXep>
+            <xmpp:xep rdf:resource="https://xmpp.org/extensions/xep-0184.html"/>
+            <xmpp:status>complete</xmpp:status>
+            <xmpp:version>1.2</xmpp:version>
+        </xmpp:SupportedXep>
+    </implements>
+    <implements>
+        <xmpp:SupportedXep>
+            <xmpp:xep rdf:resource="https://xmpp.org/extensions/xep-0199.html"/>
+            <xmpp:status>complete</xmpp:status>
+            <xmpp:version>2.0.1</xmpp:version>
+        </xmpp:SupportedXep>
+    </implements>
+    <implements>
+        <xmpp:SupportedXep>
+            <xmpp:xep rdf:resource="https://xmpp.org/extensions/xep-0203.html"/>
+            <xmpp:status>complete</xmpp:status>
+            <xmpp:version>2.0</xmpp:version>
+        </xmpp:SupportedXep>
+    </implements>
+    <implements>
+        <xmpp:SupportedXep>
+            <xmpp:xep rdf:resource="https://xmpp.org/extensions/xep-0231.html"/>
+            <xmpp:status>partial</xmpp:status>
+            <xmpp:version>1.0</xmpp:version>
+            <xmpp:note>stickers feature</xmpp:note>
+        </xmpp:SupportedXep>
+    </implements>
+    <implements>
+        <xmpp:SupportedXep>
+            <xmpp:xep rdf:resource="https://xmpp.org/extensions/xep-0245.html"/>
+            <xmpp:status>complete</xmpp:status>
+            <xmpp:version>1.0</xmpp:version>
+        </xmpp:SupportedXep>
+    </implements>
+    <implements>
+        <xmpp:SupportedXep>
+            <xmpp:xep rdf:resource="https://xmpp.org/extensions/xep-0256.html"/>
+            <xmpp:status>complete</xmpp:status>
+            <xmpp:version>1.1</xmpp:version>
+        </xmpp:SupportedXep>
+    </implements>
+    <implements>
+        <xmpp:SupportedXep>
+            <xmpp:xep rdf:resource="https://xmpp.org/extensions/xep-0277.html"/>
+            <xmpp:status>complete</xmpp:status>
+            <xmpp:version>0.6.3</xmpp:version>
+        </xmpp:SupportedXep>
+    </implements>
+    <implements>
+        <xmpp:SupportedXep>
+            <xmpp:xep rdf:resource="https://xmpp.org/extensions/xep-0280.html"/>
+            <xmpp:status>complete</xmpp:status>
+            <xmpp:version>0.11.0</xmpp:version>
+        </xmpp:SupportedXep>
+    </implements>
+    <implements>
+        <xmpp:SupportedXep>
+            <xmpp:xep rdf:resource="https://xmpp.org/extensions/xep-0292.html"/>
+            <xmpp:status>complete</xmpp:status>
+            <xmpp:version>0.10</xmpp:version>
+        </xmpp:SupportedXep>
+    </implements>
+    <implements>
+        <xmpp:SupportedXep>
+            <xmpp:xep rdf:resource="https://xmpp.org/extensions/xep-0297.html"/>
+            <xmpp:status>complete</xmpp:status>
+            <xmpp:version>1.0</xmpp:version>
+            <xmpp:since>0.8</xmpp:since>
+            <xmpp:note>only used for Carbons</xmpp:note>
+        </xmpp:SupportedXep>
+    </implements>
+    <implements>
+        <xmpp:SupportedXep>
+            <xmpp:xep rdf:resource="https://xmpp.org/extensions/xep-0308.html"/>
+            <xmpp:status>complete</xmpp:status>
+            <xmpp:version>1.0</xmpp:version>
+        </xmpp:SupportedXep>
+    </implements>
+    <implements>
+        <xmpp:SupportedXep>
+            <xmpp:xep rdf:resource="https://xmpp.org/extensions/xep-0313.html"/>
+            <xmpp:status>complete</xmpp:status>
+            <xmpp:version>0.6.3</xmpp:version>
+        </xmpp:SupportedXep>
+    </implements>
+    <implements>
+        <xmpp:SupportedXep>
+            <xmpp:xep rdf:resource="https://xmpp.org/extensions/xep-0330.html"/>
+            <xmpp:status>complete</xmpp:status>
+            <xmpp:version>0.1</xmpp:version>
+        </xmpp:SupportedXep>
+    </implements>
+    <implements>
+        <xmpp:SupportedXep>
+            <xmpp:xep rdf:resource="https://xmpp.org/extensions/xep-0333.html"/>
+            <xmpp:status>complete</xmpp:status>
+            <xmpp:version>0.3</xmpp:version>
+        </xmpp:SupportedXep>
+    </implements>
+    <implements>
+        <xmpp:SupportedXep>
+            <xmpp:xep rdf:resource="https://xmpp.org/extensions/xep-0334.html"/>
+            <xmpp:status>complete</xmpp:status>
+            <xmpp:version>0.2</xmpp:version>
+        </xmpp:SupportedXep>
+    </implements>
+    <implements>
+        <xmpp:SupportedXep>
+            <xmpp:xep rdf:resource="https://xmpp.org/extensions/xep-0359.html"/>
+            <xmpp:status>complete</xmpp:status>
+            <xmpp:version>0.6</xmpp:version>
+        </xmpp:SupportedXep>
+    </implements>
+    <implements>
+        <xmpp:SupportedXep>
+            <xmpp:xep rdf:resource="https://xmpp.org/extensions/xep-0363.html"/>
+            <xmpp:status>complete</xmpp:status>
+            <xmpp:version>0.9</xmpp:version>
+        </xmpp:SupportedXep>
+    </implements>
+    <implements>
+        <xmpp:SupportedXep>
+            <xmpp:xep rdf:resource="https://xmpp.org/extensions/xep-0367.html"/>
+            <xmpp:status>complete</xmpp:status>
+            <xmpp:version>0.3</xmpp:version>
+            <xmpp:note>for reactions</xmpp:note>
+        </xmpp:SupportedXep>
+    </implements>
+    <implements>
+        <xmpp:SupportedXep>
+            <xmpp:xep rdf:resource="https://xmpp.org/extensions/xep-0372.html"/>
+            <xmpp:status>complete</xmpp:status>
+            <xmpp:version>0.2</xmpp:version>
+        </xmpp:SupportedXep>
+    </implements>
+    <implements>
+        <xmpp:SupportedXep>
+            <xmpp:xep rdf:resource="https://xmpp.org/extensions/xep-0385.html"/>
+            <xmpp:status>partial</xmpp:status>
+            <xmpp:version>0.2.1</xmpp:version>
+        </xmpp:SupportedXep>
+    </implements>
 
     <release>
         <Version>


### PR DESCRIPTION
The xmpp-doap extension has be simplified to only expose the
SupportedXep class and its children properties, as well as categories,
and reuses DOAP to the maximum.