### PR TITLE
Improve assimilation of scrollbars into theme

### DIFF
--- a/public/theme/css/color.css
+++ b/public/theme/css/color.css
@@ -7,7 +7,8 @@ body {
     --movim-background: #EEE;
     --movim-gray: #232323;
     --movim-font: 0, 0, 0;
-    scrollbar-color: rgba(var(--movim-font), 0.3) rgba(var(--movim-font), 0.2);
+    scrollbar-color: rgba(var(--movim-font), 0.2) transparent;
+    scrollbar-width: thin;
 }
 
 body.nightmode {
@@ -16,7 +17,7 @@ body.nightmode {
     --movim-background: #192028;
     --movim-gray: var(--movim-accent);
     --movim-font: 255, 255, 255;
-    scrollbar-color: rgba(var(--movim-font), 0.1) rgba(var(--movim-background-main));
+    scrollbar-color: rgba(var(--movim-font), 0.1) transparent;
 }
 
 body {

--- a/public/theme/css/scrollbar.css
+++ b/public/theme/css/scrollbar.css
@@ -1,19 +1,24 @@
 /* Webkit specific CSS for the scrollbars */
 
-@media screen and (min-width: 1025px) {
-    ::-webkit-scrollbar {
-        width: 1.3rem;
-    }
+::-webkit-scrollbar {
+    height: 5px;
+    width: 8px;
+}
 
-    ::-webkit-scrollbar-button {
-        display: none;
-    }
+::-webkit-scrollbar-button {
+    display: none;
+}
 
-    ::-webkit-scrollbar-thumb {
-        background-color: rgba(var(--movim-font), 0.2);
-    }
+::-webkit-scrollbar-thumb {
+    background-color: rgba(var(--movim-font), 0.1);
+    border-radius: 5px;
+}
 
-    ::-webkit-scrollbar-track {
-        background-color: rgba(var(--movim-font), 0.05);
-    }
+::-webkit-scrollbar-thumb:hover {
+    background-color: rgba(var(--movim-font), 0.2);
+}
+
+::-webkit-scrollbar-track {
+    background-color: transparent;
+    border-radius: 5px;
 }


### PR DESCRIPTION
- Make bars somewhat thinner (also for Firefox)
- Prevent overlap by "To top" button in doing so
- Improve horizontal scrollbar height
- Use rounded elements for WebKit, as found throughout the entire theme
- Use the same colors as span.reaction
- Apply to narrow windows, too

