### PR TITLE
More consistent (Shift+)Enter behavior (newline or send)

### DIFF
--- a/app/widgets/Chat/chat.js
+++ b/app/widgets/Chat/chat.js
@@ -293,8 +293,8 @@ var Chat = {
                     return;
                 }
 
-                if ((MovimUtils.isMobile() && !event.shiftKey)
-                || (!MovimUtils.isMobile() && event.shiftKey)) {
+                if ((isTouch && !event.shiftKey)
+                || (!isTouch && event.shiftKey)) {
                     return;
                 }
 

--- a/public/scripts/movim_base.js
+++ b/public/scripts/movim_base.js
@@ -7,6 +7,7 @@
 var onloaders = [];
 var onfocused = [];
 var isFocused = false;
+var isTouch = false;
 
 /**
  * @brief Adds a function to the onload event
@@ -52,3 +53,4 @@ var onFocusedFunction = function() {
 window.addEventListener('mouseover', onFocusedFunction);
 window.addEventListener('focus', onFocusedFunction);
 window.addEventListener('blur', function() { isFocused = false; });
+window.addEventListener('ontouchstart', function() { isTouch = true; }, { once: true });


### PR DESCRIPTION
Let the behavior depend on whether the user is actively using a touch screen, instead of letting the screen width be the determining factor.

This should also take into account that some people have touchscreen devices, but use keyboard+mouse. In such a case, default desktop behavior (Enter = send) will be used.