### PR TITLE
Handle XEP-0353, Jingle Message Initiation, In Carbons

### DIFF
--- a/lib/moxl/src/Xec/Payload/Carbons.php
+++ b/lib/moxl/src/Xec/Payload/Carbons.php
@@ -27,6 +27,8 @@ class Carbons extends Payload
                 // Another client just displayed the message
                 $displayed = new Displayed;
                 $displayed->handle($message->displayed, $message);
+            } elseif (count($jingle_messages = $stanza->xpath('//*[@xmlns="urn:xmpp:jingle-message:0"]')) >= 1) {
+                \Moxl\Xec\Handler::handleNode($jingle_messages[0], $message);
             }
         }
     }

--- a/lib/moxl/src/Xec/Payload/Carbons.php
+++ b/lib/moxl/src/Xec/Payload/Carbons.php
@@ -28,7 +28,13 @@ class Carbons extends Payload
                 $displayed = new Displayed;
                 $displayed->handle($message->displayed, $message);
             } elseif (count($jingle_messages = $stanza->xpath('//*[@xmlns="urn:xmpp:jingle-message:0"]')) >= 1) {
-                \Moxl\Xec\Handler::handleNode($jingle_messages[0], $message);
+                $callto = current(explode('/', (string)$message->attributes()->to));
+                if ($callto == \App\User::me()->id || $callto == "") {
+                    // We get carbons for calls other clients make as well as calls other clients receive
+                    // So make sure we only ring when we see a call _to_ us
+                    // Or with no "to", which means from ourselves to ourselves, like another client's <accept>
+                    \Moxl\Xec\Handler::handleNode($jingle_messages[0], $message);
+                }
             }
         }
     }


### PR DESCRIPTION
If all clients have the same priority, then these jingle messages work
fine. They're sent to all clients, and everyone rings, whoever picks up
tells the others to stop ringing, etc.

But if one client has higher priority, then only that client will get
these jingle messages directly, and the other clients will just get a
carbon informing them of the messages.

That means that, in practice, if I have Movim and Gajim running and
someone sends a Jingle Message because Movim supports those, then Movim
won't ring. But Gajim won't know what the jingle messages are, and so I
won't be told in any way that someone's trying to call me, and they'll
think I've seen their call and I'm just ignoring them.

This implementation looks in the carbons for messages related to this
XEP, and if there are any then we handle them as though we had received
them directly.

(Closes #980)