### PR TITLE
remove username/pw check on daemon startup

### DIFF
--- a/src/Movim/Console/DaemonCommand.php
+++ b/src/Movim/Console/DaemonCommand.php
@@ -83,16 +83,6 @@ class DaemonCommand extends Command
             exit;
         }
 
-        $configuration = Configuration::get();
-
-        if (empty($configuration->username) || empty($configuration->password)) {
-            $output->writeln('<comment>Please set a username and password for the admin panel (https://yourmovimdomain/?admin)</comment>');
-
-            $output->writeln('<info>To set those credentials run</info>');
-            $output->writeln('<info>php daemon.php config --username=USERNAME --password=PASSWORD</info>');
-            exit;
-        }
-
         $locale = Locale::start();
 
         $locale->compileIni();


### PR DESCRIPTION
daemon.php on latest master fails to start after removing the username and password columns from the configuration table.

might be worthwhile to add a notice about setting a user as admin instead of setting the username/pw.