### PR TITLE
fix typos 'localy', 'globaly'

### DIFF
--- a/app/widgets/RoomsExplore/RoomsExplore.php
+++ b/app/widgets/RoomsExplore/RoomsExplore.php
@@ -42,7 +42,7 @@ class RoomsExplore extends Base
     public function onGlobalSearchError($packet)
     {
         $this->rpc('MovimTpl.fill', '#roomsexplore_global', '');
-        $this->searchLocaly($packet->content);
+        $this->searchLocally($packet->content);
     }
 
     /**
@@ -64,7 +64,7 @@ class RoomsExplore extends Base
         $configuration = \App\Configuration::get();
 
         if ($configuration->restrictsuggestions) {
-            $this->searchLocaly($keyword);
+            $this->searchLocally($keyword);
         } else {
             $s = new Search;
             $s->setKeyword($keyword)
@@ -72,7 +72,7 @@ class RoomsExplore extends Base
         }
     }
 
-    private function searchLocaly($keyword = false)
+    private function searchLocally($keyword = false)
     {
         $view = $this->tpl();
         $rooms = \App\Info::whereCategory('conference')

--- a/app/widgets/RoomsExplore/locales.ini
+++ b/app/widgets/RoomsExplore/locales.ini
@@ -1,4 +1,4 @@
 [roomsexplore]
-no_local = No chatrooms found localy
+no_local = No chatrooms found locally
 global_title = Global search
-no_global = No chatrooms found globaly
+no_global = No chatrooms found globally

--- a/locales/ach.po
+++ b/locales/ach.po
@@ -1955,7 +1955,7 @@ msgid "Always notify"
 msgstr ""
 
 #: [roomsexplore]no_local
-msgid "No chatrooms found localy"
+msgid "No chatrooms found locally"
 msgstr ""
 
 #: [roomsexplore]global_title
@@ -1963,7 +1963,7 @@ msgid "Global search"
 msgstr ""
 
 #: [roomsexplore]no_global
-msgid "No chatrooms found globaly"
+msgid "No chatrooms found globally"
 msgstr ""
 
 #: [search]keyword

--- a/locales/ady.po
+++ b/locales/ady.po
@@ -1955,7 +1955,7 @@ msgid "Always notify"
 msgstr ""
 
 #: [roomsexplore]no_local
-msgid "No chatrooms found localy"
+msgid "No chatrooms found locally"
 msgstr ""
 
 #: [roomsexplore]global_title
@@ -1963,7 +1963,7 @@ msgid "Global search"
 msgstr ""
 
 #: [roomsexplore]no_global
-msgid "No chatrooms found globaly"
+msgid "No chatrooms found globally"
 msgstr ""
 
 #: [search]keyword

--- a/locales/af.po
+++ b/locales/af.po
@@ -1955,7 +1955,7 @@ msgid "Always notify"
 msgstr ""
 
 #: [roomsexplore]no_local
-msgid "No chatrooms found localy"
+msgid "No chatrooms found locally"
 msgstr ""
 
 #: [roomsexplore]global_title
@@ -1963,7 +1963,7 @@ msgid "Global search"
 msgstr ""
 
 #: [roomsexplore]no_global
-msgid "No chatrooms found globaly"
+msgid "No chatrooms found globally"
 msgstr ""
 
 #: [search]keyword

--- a/locales/am.po
+++ b/locales/am.po
@@ -1955,7 +1955,7 @@ msgid "Always notify"
 msgstr ""
 
 #: [roomsexplore]no_local
-msgid "No chatrooms found localy"
+msgid "No chatrooms found locally"
 msgstr ""
 
 #: [roomsexplore]global_title
@@ -1963,7 +1963,7 @@ msgid "Global search"
 msgstr ""
 
 #: [roomsexplore]no_global
-msgid "No chatrooms found globaly"
+msgid "No chatrooms found globally"
 msgstr ""
 
 #: [search]keyword

--- a/locales/ar.po
+++ b/locales/ar.po
@@ -1958,7 +1958,7 @@ msgid "Always notify"
 msgstr ""
 
 #: [roomsexplore]no_local
-msgid "No chatrooms found localy"
+msgid "No chatrooms found locally"
 msgstr ""
 
 #: [roomsexplore]global_title
@@ -1966,7 +1966,7 @@ msgid "Global search"
 msgstr ""
 
 #: [roomsexplore]no_global
-msgid "No chatrooms found globaly"
+msgid "No chatrooms found globally"
 msgstr ""
 
 #: [search]keyword

--- a/locales/be.po
+++ b/locales/be.po
@@ -1955,7 +1955,7 @@ msgid "Always notify"
 msgstr ""
 
 #: [roomsexplore]no_local
-msgid "No chatrooms found localy"
+msgid "No chatrooms found locally"
 msgstr ""
 
 #: [roomsexplore]global_title
@@ -1963,7 +1963,7 @@ msgid "Global search"
 msgstr ""
 
 #: [roomsexplore]no_global
-msgid "No chatrooms found globaly"
+msgid "No chatrooms found globally"
 msgstr ""
 
 #: [search]keyword

--- a/locales/bg.po
+++ b/locales/bg.po
@@ -1957,7 +1957,7 @@ msgid "Always notify"
 msgstr ""
 
 #: [roomsexplore]no_local
-msgid "No chatrooms found localy"
+msgid "No chatrooms found locally"
 msgstr ""
 
 #: [roomsexplore]global_title
@@ -1965,7 +1965,7 @@ msgid "Global search"
 msgstr ""
 
 #: [roomsexplore]no_global
-msgid "No chatrooms found globaly"
+msgid "No chatrooms found globally"
 msgstr ""
 
 #: [search]keyword

--- a/locales/bn.po
+++ b/locales/bn.po
@@ -1956,7 +1956,7 @@ msgid "Always notify"
 msgstr ""
 
 #: [roomsexplore]no_local
-msgid "No chatrooms found localy"
+msgid "No chatrooms found locally"
 msgstr ""
 
 #: [roomsexplore]global_title
@@ -1964,7 +1964,7 @@ msgid "Global search"
 msgstr ""
 
 #: [roomsexplore]no_global
-msgid "No chatrooms found globaly"
+msgid "No chatrooms found globally"
 msgstr ""
 
 #: [search]keyword

--- a/locales/br.po
+++ b/locales/br.po
@@ -1957,7 +1957,7 @@ msgid "Always notify"
 msgstr ""
 
 #: [roomsexplore]no_local
-msgid "No chatrooms found localy"
+msgid "No chatrooms found locally"
 msgstr ""
 
 #: [roomsexplore]global_title
@@ -1965,7 +1965,7 @@ msgid "Global search"
 msgstr ""
 
 #: [roomsexplore]no_global
-msgid "No chatrooms found globaly"
+msgid "No chatrooms found globally"
 msgstr ""
 
 #: [search]keyword

--- a/locales/ca.po
+++ b/locales/ca.po
@@ -1960,7 +1960,7 @@ msgid "Always notify"
 msgstr ""
 
 #: [roomsexplore]no_local
-msgid "No chatrooms found localy"
+msgid "No chatrooms found locally"
 msgstr ""
 
 #: [roomsexplore]global_title
@@ -1968,7 +1968,7 @@ msgid "Global search"
 msgstr ""
 
 #: [roomsexplore]no_global
-msgid "No chatrooms found globaly"
+msgid "No chatrooms found globally"
 msgstr ""
 
 #: [search]keyword

--- a/locales/cs.po
+++ b/locales/cs.po
@@ -1963,7 +1963,7 @@ msgid "Always notify"
 msgstr ""
 
 #: [roomsexplore]no_local
-msgid "No chatrooms found localy"
+msgid "No chatrooms found locally"
 msgstr ""
 
 #: [roomsexplore]global_title
@@ -1971,7 +1971,7 @@ msgid "Global search"
 msgstr ""
 
 #: [roomsexplore]no_global
-msgid "No chatrooms found globaly"
+msgid "No chatrooms found globally"
 msgstr ""
 
 #: [search]keyword

--- a/locales/da.po
+++ b/locales/da.po
@@ -1960,7 +1960,7 @@ msgid "Always notify"
 msgstr ""
 
 #: [roomsexplore]no_local
-msgid "No chatrooms found localy"
+msgid "No chatrooms found locally"
 msgstr ""
 
 #: [roomsexplore]global_title
@@ -1968,7 +1968,7 @@ msgid "Global search"
 msgstr ""
 
 #: [roomsexplore]no_global
-msgid "No chatrooms found globaly"
+msgid "No chatrooms found globally"
 msgstr ""
 
 #: [search]keyword

--- a/locales/de.po
+++ b/locales/de.po
@@ -1977,7 +1977,7 @@ msgid "Always notify"
 msgstr ""
 
 #: [roomsexplore]no_local
-msgid "No chatrooms found localy"
+msgid "No chatrooms found locally"
 msgstr "Keine lokalen Chaträume gefunden"
 
 #: [roomsexplore]global_title
@@ -1985,7 +1985,7 @@ msgid "Global search"
 msgstr "Globale Suche"
 
 #: [roomsexplore]no_global
-msgid "No chatrooms found globaly"
+msgid "No chatrooms found globally"
 msgstr "Keine globalen Chaträume gefunden"
 
 #: [search]keyword

--- a/locales/el.po
+++ b/locales/el.po
@@ -1958,7 +1958,7 @@ msgid "Always notify"
 msgstr ""
 
 #: [roomsexplore]no_local
-msgid "No chatrooms found localy"
+msgid "No chatrooms found locally"
 msgstr ""
 
 #: [roomsexplore]global_title
@@ -1966,7 +1966,7 @@ msgid "Global search"
 msgstr ""
 
 #: [roomsexplore]no_global
-msgid "No chatrooms found globaly"
+msgid "No chatrooms found globally"
 msgstr ""
 
 #: [search]keyword

--- a/locales/en.po
+++ b/locales/en.po
@@ -1961,16 +1961,16 @@ msgid "Always notify"
 msgstr "Always notify"
 
 #: [roomsexplore]no_local
-msgid "No chatrooms found localy"
-msgstr "No chatrooms found localy"
+msgid "No chatrooms found locally"
+msgstr "No chatrooms found locally"
 
 #: [roomsexplore]global_title
 msgid "Global search"
 msgstr "Global search"
 
 #: [roomsexplore]no_global
-msgid "No chatrooms found globaly"
-msgstr "No chatrooms found globaly"
+msgid "No chatrooms found globally"
+msgstr "No chatrooms found globally"
 
 #: [search]keyword
 msgid "What are you looking for?"

--- a/locales/eo.po
+++ b/locales/eo.po
@@ -1955,7 +1955,7 @@ msgid "Always notify"
 msgstr ""
 
 #: [roomsexplore]no_local
-msgid "No chatrooms found localy"
+msgid "No chatrooms found locally"
 msgstr ""
 
 #: [roomsexplore]global_title
@@ -1963,7 +1963,7 @@ msgid "Global search"
 msgstr ""
 
 #: [roomsexplore]no_global
-msgid "No chatrooms found globaly"
+msgid "No chatrooms found globally"
 msgstr ""
 
 #: [search]keyword

--- a/locales/es.po
+++ b/locales/es.po
@@ -1971,7 +1971,7 @@ msgid "Always notify"
 msgstr ""
 
 #: [roomsexplore]no_local
-msgid "No chatrooms found localy"
+msgid "No chatrooms found locally"
 msgstr "No se encuentran salas de conversación locales"
 
 #: [roomsexplore]global_title
@@ -1979,7 +1979,7 @@ msgid "Global search"
 msgstr "Búsqueda global"
 
 #: [roomsexplore]no_global
-msgid "No chatrooms found globaly"
+msgid "No chatrooms found globally"
 msgstr "No se encuentran salas de conversación globales"
 
 #: [search]keyword

--- a/locales/eu.po
+++ b/locales/eu.po
@@ -1955,7 +1955,7 @@ msgid "Always notify"
 msgstr ""
 
 #: [roomsexplore]no_local
-msgid "No chatrooms found localy"
+msgid "No chatrooms found locally"
 msgstr ""
 
 #: [roomsexplore]global_title
@@ -1963,7 +1963,7 @@ msgid "Global search"
 msgstr ""
 
 #: [roomsexplore]no_global
-msgid "No chatrooms found globaly"
+msgid "No chatrooms found globally"
 msgstr ""
 
 #: [search]keyword

--- a/locales/fa.po
+++ b/locales/fa.po
@@ -1963,7 +1963,7 @@ msgid "Always notify"
 msgstr "همیشه به من اطلاع بده"
 
 #: [roomsexplore]no_local
-msgid "No chatrooms found localy"
+msgid "No chatrooms found locally"
 msgstr "هیچ چت روم محلی ایی پیدا نشد"
 
 #: [roomsexplore]global_title
@@ -1971,7 +1971,7 @@ msgid "Global search"
 msgstr "سرچ کلی"
 
 #: [roomsexplore]no_global
-msgid "No chatrooms found globaly"
+msgid "No chatrooms found globally"
 msgstr ""
 
 #: [search]keyword

--- a/locales/fi.po
+++ b/locales/fi.po
@@ -1958,7 +1958,7 @@ msgid "Always notify"
 msgstr ""
 
 #: [roomsexplore]no_local
-msgid "No chatrooms found localy"
+msgid "No chatrooms found locally"
 msgstr ""
 
 #: [roomsexplore]global_title
@@ -1966,7 +1966,7 @@ msgid "Global search"
 msgstr ""
 
 #: [roomsexplore]no_global
-msgid "No chatrooms found globaly"
+msgid "No chatrooms found globally"
 msgstr ""
 
 #: [search]keyword

--- a/locales/fr.po
+++ b/locales/fr.po
@@ -1965,7 +1965,7 @@ msgid "Always notify"
 msgstr "Toujours notifier"
 
 #: [roomsexplore]no_local
-msgid "No chatrooms found localy"
+msgid "No chatrooms found locally"
 msgstr "Pas de salons de discussion trouvés localement"
 
 #: [roomsexplore]global_title
@@ -1973,7 +1973,7 @@ msgid "Global search"
 msgstr "Recherche globale"
 
 #: [roomsexplore]no_global
-msgid "No chatrooms found globaly"
+msgid "No chatrooms found globally"
 msgstr "Pas de salons de discussion trouvés globalement"
 
 #: [search]keyword

--- a/locales/ga.po
+++ b/locales/ga.po
@@ -1956,7 +1956,7 @@ msgid "Always notify"
 msgstr ""
 
 #: [roomsexplore]no_local
-msgid "No chatrooms found localy"
+msgid "No chatrooms found locally"
 msgstr ""
 
 #: [roomsexplore]global_title
@@ -1964,7 +1964,7 @@ msgid "Global search"
 msgstr ""
 
 #: [roomsexplore]no_global
-msgid "No chatrooms found globaly"
+msgid "No chatrooms found globally"
 msgstr ""
 
 #: [search]keyword

--- a/locales/gl.po
+++ b/locales/gl.po
@@ -1955,7 +1955,7 @@ msgid "Always notify"
 msgstr ""
 
 #: [roomsexplore]no_local
-msgid "No chatrooms found localy"
+msgid "No chatrooms found locally"
 msgstr ""
 
 #: [roomsexplore]global_title
@@ -1963,7 +1963,7 @@ msgid "Global search"
 msgstr ""
 
 #: [roomsexplore]no_global
-msgid "No chatrooms found globaly"
+msgid "No chatrooms found globally"
 msgstr ""
 
 #: [search]keyword

--- a/locales/he.po
+++ b/locales/he.po
@@ -1961,7 +1961,7 @@ msgid "Always notify"
 msgstr ""
 
 #: [roomsexplore]no_local
-msgid "No chatrooms found localy"
+msgid "No chatrooms found locally"
 msgstr ""
 
 #: [roomsexplore]global_title
@@ -1969,7 +1969,7 @@ msgid "Global search"
 msgstr ""
 
 #: [roomsexplore]no_global
-msgid "No chatrooms found globaly"
+msgid "No chatrooms found globally"
 msgstr ""
 
 #: [search]keyword

--- a/locales/hr.po
+++ b/locales/hr.po
@@ -1960,7 +1960,7 @@ msgid "Always notify"
 msgstr ""
 
 #: [roomsexplore]no_local
-msgid "No chatrooms found localy"
+msgid "No chatrooms found locally"
 msgstr ""
 
 #: [roomsexplore]global_title
@@ -1968,7 +1968,7 @@ msgid "Global search"
 msgstr ""
 
 #: [roomsexplore]no_global
-msgid "No chatrooms found globaly"
+msgid "No chatrooms found globally"
 msgstr ""
 
 #: [search]keyword

--- a/locales/hu.po
+++ b/locales/hu.po
@@ -1964,7 +1964,7 @@ msgid "Always notify"
 msgstr ""
 
 #: [roomsexplore]no_local
-msgid "No chatrooms found localy"
+msgid "No chatrooms found locally"
 msgstr ""
 
 #: [roomsexplore]global_title
@@ -1972,7 +1972,7 @@ msgid "Global search"
 msgstr ""
 
 #: [roomsexplore]no_global
-msgid "No chatrooms found globaly"
+msgid "No chatrooms found globally"
 msgstr ""
 
 #: [search]keyword

--- a/locales/id.po
+++ b/locales/id.po
@@ -1962,7 +1962,7 @@ msgid "Always notify"
 msgstr ""
 
 #: [roomsexplore]no_local
-msgid "No chatrooms found localy"
+msgid "No chatrooms found locally"
 msgstr ""
 
 #: [roomsexplore]global_title
@@ -1970,7 +1970,7 @@ msgid "Global search"
 msgstr ""
 
 #: [roomsexplore]no_global
-msgid "No chatrooms found globaly"
+msgid "No chatrooms found globally"
 msgstr ""
 
 #: [search]keyword

--- a/locales/io.po
+++ b/locales/io.po
@@ -1958,7 +1958,7 @@ msgid "Always notify"
 msgstr ""
 
 #: [roomsexplore]no_local
-msgid "No chatrooms found localy"
+msgid "No chatrooms found locally"
 msgstr ""
 
 #: [roomsexplore]global_title
@@ -1966,7 +1966,7 @@ msgid "Global search"
 msgstr ""
 
 #: [roomsexplore]no_global
-msgid "No chatrooms found globaly"
+msgid "No chatrooms found globally"
 msgstr ""
 
 #: [search]keyword

--- a/locales/is.po
+++ b/locales/is.po
@@ -1958,7 +1958,7 @@ msgid "Always notify"
 msgstr ""
 
 #: [roomsexplore]no_local
-msgid "No chatrooms found localy"
+msgid "No chatrooms found locally"
 msgstr ""
 
 #: [roomsexplore]global_title
@@ -1966,7 +1966,7 @@ msgid "Global search"
 msgstr ""
 
 #: [roomsexplore]no_global
-msgid "No chatrooms found globaly"
+msgid "No chatrooms found globally"
 msgstr ""
 
 #: [search]keyword

--- a/locales/it.po
+++ b/locales/it.po
@@ -1968,7 +1968,7 @@ msgid "Always notify"
 msgstr ""
 
 #: [roomsexplore]no_local
-msgid "No chatrooms found localy"
+msgid "No chatrooms found locally"
 msgstr ""
 
 #: [roomsexplore]global_title
@@ -1976,7 +1976,7 @@ msgid "Global search"
 msgstr ""
 
 #: [roomsexplore]no_global
-msgid "No chatrooms found globaly"
+msgid "No chatrooms found globally"
 msgstr ""
 
 #: [search]keyword

--- a/locales/ja.po
+++ b/locales/ja.po
@@ -1966,7 +1966,7 @@ msgid "Always notify"
 msgstr "常に通知する"
 
 #: [roomsexplore]no_local
-msgid "No chatrooms found localy"
+msgid "No chatrooms found locally"
 msgstr "ローカルでチャットルームが見つかりませんでした"
 
 #: [roomsexplore]global_title
@@ -1974,7 +1974,7 @@ msgid "Global search"
 msgstr "グローバル検索"
 
 #: [roomsexplore]no_global
-msgid "No chatrooms found globaly"
+msgid "No chatrooms found globally"
 msgstr "グローバルでチャットルームが見つかりませんでした"
 
 #: [search]keyword

--- a/locales/jbo.po
+++ b/locales/jbo.po
@@ -1956,7 +1956,7 @@ msgid "Always notify"
 msgstr ""
 
 #: [roomsexplore]no_local
-msgid "No chatrooms found localy"
+msgid "No chatrooms found locally"
 msgstr ""
 
 #: [roomsexplore]global_title
@@ -1964,7 +1964,7 @@ msgid "Global search"
 msgstr ""
 
 #: [roomsexplore]no_global
-msgid "No chatrooms found globaly"
+msgid "No chatrooms found globally"
 msgstr ""
 
 #: [search]keyword

--- a/locales/kk.po
+++ b/locales/kk.po
@@ -1955,7 +1955,7 @@ msgid "Always notify"
 msgstr ""
 
 #: [roomsexplore]no_local
-msgid "No chatrooms found localy"
+msgid "No chatrooms found locally"
 msgstr ""
 
 #: [roomsexplore]global_title
@@ -1963,7 +1963,7 @@ msgid "Global search"
 msgstr ""
 
 #: [roomsexplore]no_global
-msgid "No chatrooms found globaly"
+msgid "No chatrooms found globally"
 msgstr ""
 
 #: [search]keyword

--- a/locales/ko.po
+++ b/locales/ko.po
@@ -1957,7 +1957,7 @@ msgid "Always notify"
 msgstr ""
 
 #: [roomsexplore]no_local
-msgid "No chatrooms found localy"
+msgid "No chatrooms found locally"
 msgstr ""
 
 #: [roomsexplore]global_title
@@ -1965,7 +1965,7 @@ msgid "Global search"
 msgstr ""
 
 #: [roomsexplore]no_global
-msgid "No chatrooms found globaly"
+msgid "No chatrooms found globally"
 msgstr ""
 
 #: [search]keyword

--- a/locales/lb.po
+++ b/locales/lb.po
@@ -1955,7 +1955,7 @@ msgid "Always notify"
 msgstr ""
 
 #: [roomsexplore]no_local
-msgid "No chatrooms found localy"
+msgid "No chatrooms found locally"
 msgstr ""
 
 #: [roomsexplore]global_title
@@ -1963,7 +1963,7 @@ msgid "Global search"
 msgstr ""
 
 #: [roomsexplore]no_global
-msgid "No chatrooms found globaly"
+msgid "No chatrooms found globally"
 msgstr ""
 
 #: [search]keyword

--- a/locales/lt.po
+++ b/locales/lt.po
@@ -1957,7 +1957,7 @@ msgid "Always notify"
 msgstr ""
 
 #: [roomsexplore]no_local
-msgid "No chatrooms found localy"
+msgid "No chatrooms found locally"
 msgstr ""
 
 #: [roomsexplore]global_title
@@ -1965,7 +1965,7 @@ msgid "Global search"
 msgstr ""
 
 #: [roomsexplore]no_global
-msgid "No chatrooms found globaly"
+msgid "No chatrooms found globally"
 msgstr ""
 
 #: [search]keyword

--- a/locales/lv.po
+++ b/locales/lv.po
@@ -1959,7 +1959,7 @@ msgid "Always notify"
 msgstr ""
 
 #: [roomsexplore]no_local
-msgid "No chatrooms found localy"
+msgid "No chatrooms found locally"
 msgstr ""
 
 #: [roomsexplore]global_title
@@ -1967,7 +1967,7 @@ msgid "Global search"
 msgstr ""
 
 #: [roomsexplore]no_global
-msgid "No chatrooms found globaly"
+msgid "No chatrooms found globally"
 msgstr ""
 
 #: [search]keyword

--- a/locales/messages.pot
+++ b/locales/messages.pot
@@ -2557,7 +2557,7 @@ msgid "Always notify"
 msgstr ""
 
 #: [roomsexplore]no_local
-msgid "No chatrooms found localy"
+msgid "No chatrooms found locally"
 msgstr ""
 
 #: [roomsexplore]global_title
@@ -2565,7 +2565,7 @@ msgid "Global search"
 msgstr ""
 
 #: [roomsexplore]no_global
-msgid "No chatrooms found globaly"
+msgid "No chatrooms found globally"
 msgstr ""
 
 #: [search]keyword

--- a/locales/messages/app/widgets/RoomsExplore/locales.po
+++ b/locales/messages/app/widgets/RoomsExplore/locales.po
@@ -14,7 +14,7 @@ msgstr ""
 "X-Generator: Translate Toolkit 3.3.2\n"
 
 #: [roomsexplore]no_local
-msgid "No chatrooms found localy"
+msgid "No chatrooms found locally"
 msgstr ""
 
 #: [roomsexplore]global_title
@@ -22,5 +22,5 @@ msgid "Global search"
 msgstr ""
 
 #: [roomsexplore]no_global
-msgid "No chatrooms found globaly"
+msgid "No chatrooms found globally"
 msgstr ""

--- a/locales/nb.po
+++ b/locales/nb.po
@@ -1965,7 +1965,7 @@ msgid "Always notify"
 msgstr ""
 
 #: [roomsexplore]no_local
-msgid "No chatrooms found localy"
+msgid "No chatrooms found locally"
 msgstr ""
 
 #: [roomsexplore]global_title
@@ -1973,7 +1973,7 @@ msgid "Global search"
 msgstr ""
 
 #: [roomsexplore]no_global
-msgid "No chatrooms found globaly"
+msgid "No chatrooms found globally"
 msgstr ""
 
 #: [search]keyword

--- a/locales/ne.po
+++ b/locales/ne.po
@@ -1956,7 +1956,7 @@ msgid "Always notify"
 msgstr ""
 
 #: [roomsexplore]no_local
-msgid "No chatrooms found localy"
+msgid "No chatrooms found locally"
 msgstr ""
 
 #: [roomsexplore]global_title
@@ -1964,7 +1964,7 @@ msgid "Global search"
 msgstr ""
 
 #: [roomsexplore]no_global
-msgid "No chatrooms found globaly"
+msgid "No chatrooms found globally"
 msgstr ""
 
 #: [search]keyword

--- a/locales/nl.po
+++ b/locales/nl.po
@@ -1970,7 +1970,7 @@ msgid "Always notify"
 msgstr ""
 
 #: [roomsexplore]no_local
-msgid "No chatrooms found localy"
+msgid "No chatrooms found locally"
 msgstr ""
 
 #: [roomsexplore]global_title
@@ -1978,7 +1978,7 @@ msgid "Global search"
 msgstr ""
 
 #: [roomsexplore]no_global
-msgid "No chatrooms found globaly"
+msgid "No chatrooms found globally"
 msgstr ""
 
 #: [search]keyword

--- a/locales/oc.po
+++ b/locales/oc.po
@@ -1956,7 +1956,7 @@ msgid "Always notify"
 msgstr ""
 
 #: [roomsexplore]no_local
-msgid "No chatrooms found localy"
+msgid "No chatrooms found locally"
 msgstr ""
 
 #: [roomsexplore]global_title
@@ -1964,7 +1964,7 @@ msgid "Global search"
 msgstr ""
 
 #: [roomsexplore]no_global
-msgid "No chatrooms found globaly"
+msgid "No chatrooms found globally"
 msgstr ""
 
 #: [search]keyword

--- a/locales/pl.po
+++ b/locales/pl.po
@@ -1963,7 +1963,7 @@ msgid "Always notify"
 msgstr ""
 
 #: [roomsexplore]no_local
-msgid "No chatrooms found localy"
+msgid "No chatrooms found locally"
 msgstr ""
 
 #: [roomsexplore]global_title
@@ -1971,7 +1971,7 @@ msgid "Global search"
 msgstr ""
 
 #: [roomsexplore]no_global
-msgid "No chatrooms found globaly"
+msgid "No chatrooms found globally"
 msgstr ""
 
 #: [search]keyword

--- a/locales/pt.po
+++ b/locales/pt.po
@@ -1959,7 +1959,7 @@ msgid "Always notify"
 msgstr ""
 
 #: [roomsexplore]no_local
-msgid "No chatrooms found localy"
+msgid "No chatrooms found locally"
 msgstr ""
 
 #: [roomsexplore]global_title
@@ -1967,7 +1967,7 @@ msgid "Global search"
 msgstr ""
 
 #: [roomsexplore]no_global
-msgid "No chatrooms found globaly"
+msgid "No chatrooms found globally"
 msgstr ""
 
 #: [search]keyword

--- a/locales/pt_br.po
+++ b/locales/pt_br.po
@@ -1973,7 +1973,7 @@ msgid "Always notify"
 msgstr "Notifique sempre"
 
 #: [roomsexplore]no_local
-msgid "No chatrooms found localy"
+msgid "No chatrooms found locally"
 msgstr "Nenhuma sala de bate-papo foi encontrada localmente"
 
 #: [roomsexplore]global_title
@@ -1981,7 +1981,7 @@ msgid "Global search"
 msgstr "Busca global"
 
 #: [roomsexplore]no_global
-msgid "No chatrooms found globaly"
+msgid "No chatrooms found globally"
 msgstr "Nenhuma sala de bate-papo for encontrada globalmente"
 
 #: [search]keyword

--- a/locales/ro.po
+++ b/locales/ro.po
@@ -1960,7 +1960,7 @@ msgid "Always notify"
 msgstr ""
 
 #: [roomsexplore]no_local
-msgid "No chatrooms found localy"
+msgid "No chatrooms found locally"
 msgstr ""
 
 #: [roomsexplore]global_title
@@ -1968,7 +1968,7 @@ msgid "Global search"
 msgstr ""
 
 #: [roomsexplore]no_global
-msgid "No chatrooms found globaly"
+msgid "No chatrooms found globally"
 msgstr ""
 
 #: [search]keyword

--- a/locales/ru.po
+++ b/locales/ru.po
@@ -1976,7 +1976,7 @@ msgid "Always notify"
 msgstr ""
 
 #: [roomsexplore]no_local
-msgid "No chatrooms found localy"
+msgid "No chatrooms found locally"
 msgstr "Локальных комнат не найдено"
 
 #: [roomsexplore]global_title
@@ -1984,7 +1984,7 @@ msgid "Global search"
 msgstr "Глобальный поиск"
 
 #: [roomsexplore]no_global
-msgid "No chatrooms found globaly"
+msgid "No chatrooms found globally"
 msgstr ""
 
 #: [search]keyword

--- a/locales/sk.po
+++ b/locales/sk.po
@@ -1964,7 +1964,7 @@ msgid "Always notify"
 msgstr "Vždy upozorniť"
 
 #: [roomsexplore]no_local
-msgid "No chatrooms found localy"
+msgid "No chatrooms found locally"
 msgstr "Nenájdené žiadne lokálne miestnosti"
 
 #: [roomsexplore]global_title
@@ -1972,7 +1972,7 @@ msgid "Global search"
 msgstr "Globálne hľadanie"
 
 #: [roomsexplore]no_global
-msgid "No chatrooms found globaly"
+msgid "No chatrooms found globally"
 msgstr "Nenájdené žiadne globálne miestnosti"
 
 #: [search]keyword

--- a/locales/sl.po
+++ b/locales/sl.po
@@ -1955,7 +1955,7 @@ msgid "Always notify"
 msgstr ""
 
 #: [roomsexplore]no_local
-msgid "No chatrooms found localy"
+msgid "No chatrooms found locally"
 msgstr ""
 
 #: [roomsexplore]global_title
@@ -1963,7 +1963,7 @@ msgid "Global search"
 msgstr ""
 
 #: [roomsexplore]no_global
-msgid "No chatrooms found globaly"
+msgid "No chatrooms found globally"
 msgstr ""
 
 #: [search]keyword

--- a/locales/sq.po
+++ b/locales/sq.po
@@ -1964,7 +1964,7 @@ msgid "Always notify"
 msgstr "Njofto përherë"
 
 #: [roomsexplore]no_local
-msgid "No chatrooms found localy"
+msgid "No chatrooms found locally"
 msgstr "S’u gjetën dhoma fjalosjes vendore"
 
 #: [roomsexplore]global_title
@@ -1972,7 +1972,7 @@ msgid "Global search"
 msgstr "Kërkim global"
 
 #: [roomsexplore]no_global
-msgid "No chatrooms found globaly"
+msgid "No chatrooms found globally"
 msgstr "S’u gjetën dhoma fjalosjesh globale"
 
 #: [search]keyword

--- a/locales/sv.po
+++ b/locales/sv.po
@@ -1958,7 +1958,7 @@ msgid "Always notify"
 msgstr ""
 
 #: [roomsexplore]no_local
-msgid "No chatrooms found localy"
+msgid "No chatrooms found locally"
 msgstr ""
 
 #: [roomsexplore]global_title
@@ -1966,7 +1966,7 @@ msgid "Global search"
 msgstr ""
 
 #: [roomsexplore]no_global
-msgid "No chatrooms found globaly"
+msgid "No chatrooms found globally"
 msgstr ""
 
 #: [search]keyword

--- a/locales/sw.po
+++ b/locales/sw.po
@@ -1955,7 +1955,7 @@ msgid "Always notify"
 msgstr ""
 
 #: [roomsexplore]no_local
-msgid "No chatrooms found localy"
+msgid "No chatrooms found locally"
 msgstr ""
 
 #: [roomsexplore]global_title
@@ -1963,7 +1963,7 @@ msgid "Global search"
 msgstr ""
 
 #: [roomsexplore]no_global
-msgid "No chatrooms found globaly"
+msgid "No chatrooms found globally"
 msgstr ""
 
 #: [search]keyword

--- a/locales/tr.po
+++ b/locales/tr.po
@@ -1959,7 +1959,7 @@ msgid "Always notify"
 msgstr ""
 
 #: [roomsexplore]no_local
-msgid "No chatrooms found localy"
+msgid "No chatrooms found locally"
 msgstr ""
 
 #: [roomsexplore]global_title
@@ -1967,7 +1967,7 @@ msgid "Global search"
 msgstr ""
 
 #: [roomsexplore]no_global
-msgid "No chatrooms found globaly"
+msgid "No chatrooms found globally"
 msgstr ""
 
 #: [search]keyword

--- a/locales/uk.po
+++ b/locales/uk.po
@@ -1957,7 +1957,7 @@ msgid "Always notify"
 msgstr ""
 
 #: [roomsexplore]no_local
-msgid "No chatrooms found localy"
+msgid "No chatrooms found locally"
 msgstr ""
 
 #: [roomsexplore]global_title
@@ -1965,7 +1965,7 @@ msgid "Global search"
 msgstr ""
 
 #: [roomsexplore]no_global
-msgid "No chatrooms found globaly"
+msgid "No chatrooms found globally"
 msgstr ""
 
 #: [search]keyword

--- a/locales/vi.po
+++ b/locales/vi.po
@@ -1956,7 +1956,7 @@ msgid "Always notify"
 msgstr ""
 
 #: [roomsexplore]no_local
-msgid "No chatrooms found localy"
+msgid "No chatrooms found locally"
 msgstr ""
 
 #: [roomsexplore]global_title
@@ -1964,7 +1964,7 @@ msgid "Global search"
 msgstr ""
 
 #: [roomsexplore]no_global
-msgid "No chatrooms found globaly"
+msgid "No chatrooms found globally"
 msgstr ""
 
 #: [search]keyword

--- a/locales/zh.po
+++ b/locales/zh.po
@@ -1971,7 +1971,7 @@ msgid "Always notify"
 msgstr "总是通知"
 
 #: [roomsexplore]no_local
-msgid "No chatrooms found localy"
+msgid "No chatrooms found locally"
 msgstr "在本地找不到聊天室"
 
 #: [roomsexplore]global_title
@@ -1979,7 +1979,7 @@ msgid "Global search"
 msgstr ""
 
 #: [roomsexplore]no_global
-msgid "No chatrooms found globaly"
+msgid "No chatrooms found globally"
 msgstr ""
 
 #: [search]keyword

--- a/locales/zh_tw.po
+++ b/locales/zh_tw.po
@@ -1959,7 +1959,7 @@ msgid "Always notify"
 msgstr ""
 
 #: [roomsexplore]no_local
-msgid "No chatrooms found localy"
+msgid "No chatrooms found locally"
 msgstr ""
 
 #: [roomsexplore]global_title
@@ -1967,7 +1967,7 @@ msgid "Global search"
 msgstr ""
 
 #: [roomsexplore]no_global
-msgid "No chatrooms found globaly"
+msgid "No chatrooms found globally"
 msgstr ""
 
 #: [search]keyword


### PR DESCRIPTION
**Replace misspelled words 'localy' and 'globaly' with 'locally' and 'globally'**. See:
1. https://www.spellcheck.net/misspelled-words/localy
2. https://www.spellcheck.net/misspelled-words/globaly

Why this matters:
![Screenshot 2021-07-28 at 18-38-26 Chats](https://user-images.githubusercontent.com/47838810/127418222-66469d4a-e18b-4423-b236-56a75babbc3f.png)
Because users can see the misspelled word.

Notes:
1. Renames a `private function` in `app/widgets/RoomsExplore/RoomsExplore.php` from `searchLocaly` to `searchLocally`.
2. Adds a newline to the end of files `app/widgets/RoomsExplore/RoomsExplore.php` and `app/widgets/RoomsExplore/locales.ini`. See:
a. [POSIX.1-2017 § 3.206 Line](https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap03.html#tag_03_206)
b. [PSR-12 § 2.2 Files](https://www.php-fig.org/psr/psr-12/#22-files)