### PR TITLE
Add style parsing for XEP-0393 styling directives.

### DIFF
--- a/app/widgets/Chat/Chat.php
+++ b/app/widgets/Chat/Chat.php
@@ -1056,6 +1056,12 @@ class Chat extends \Movim\Widget\Base
 
     public function prepareMessage(&$message, $jid = null)
     {
+        $message->body = (preg_replace ('/```((.|\n)*?)(```|\z)/', "<pre>$1</pre>", $message->body));
+        $message->body = (preg_replace ('/(`(?!`).*?`)/', "<code>$1</code>", $message->body));
+        $message->body = (preg_replace ('/(\*.*?\*)/', "<b>$1</b>", $message->body));
+        $message->body = (preg_replace ('/(_.*?_)/', "<em>$1</em>", $message->body));
+        $message->body = (preg_replace ('/(~.*?~)/', "<s>$1</s>", $message->body));
+
         if ($jid != $message->jidto && $jid != $message->jidfrom && $jid != null) {
             return $this->_wrapper;
         }

--- a/app/widgets/Chat/chat.css
+++ b/app/widgets/Chat/chat.css
@@ -5,6 +5,11 @@
     overflow: hidden;
 }
 
+code *, pre * {
+    font-style: normal;
+    font-weight: normal;
+}
+
 main:not(.enabled) #chat_widget {
     overflow-y: auto;
 }

--- a/app/widgets/Chat/chat.js
+++ b/app/widgets/Chat/chat.js
@@ -1002,16 +1002,6 @@ var Chat = {
             span.appendChild(Chat.getEncryptedIcoHtml());
         }
 
-        if (data.body.match(/^\/me\s/)) {
-            p.classList.add('quote');
-            data.body = data.body.substr(4);
-        }
-
-        if (data.body.match(/^\/code\s/)) {
-            p.classList.add('code');
-            data.body = data.body.substr(6).trim();
-        }
-
         if (data.id != null) {
             msg.setAttribute('id', 'id' + data.id);
         }


### PR DESCRIPTION
This should resolve #1027. Do note that nested quotes haven't been implemented as I don't fully understand how quotes work in Movim, but this should be good enough for a rudimentary implementation. I also had some trouble getting the regex not to match styling directives contained within blocks or spans of preformatted text, so instead I just overrode their styling in the associated CSS stylesheet. I also removed /code and /me as they should no longer be needed now that we have support for XEP-0393.