### PR TITLE
Correct XEP-0393 Style Parsing

### DIFF
--- a/app/widgets/Chat/Chat.php
+++ b/app/widgets/Chat/Chat.php
@@ -1101,10 +1101,10 @@ class Chat extends \Movim\Widget\Base
 
         // XEP-0393
         // $message->body = (preg_replace ('/```((.|\n)*?)(```|\z)/', "<pre>$1</pre>", $message->body));
-        $message->body = (preg_replace ('/(?<!\S)(`(?!`).*?`)(?!\S)/', "<code>$1</code>", $message->body));
-        $message->body = (preg_replace ('/(?<!\S)(\*.*?\*)(?!\S)/', "<b>$1</b>", $message->body));
-        $message->body = (preg_replace ('/(?<!\S)(_.*?_)(?!\S)/', "<em>$1</em>", $message->body));
-        $message->body = (preg_replace ('/(?<!\S)(~.*?~)(?!\S)/', "<s>$1</s>", $message->body));
+        $message->body = (preg_replace ('/(?<=^|[\s,\*,_,~])(`(?!\s).+?(?<!\s)`)/', "$1</code>", $message->body));
+        $message->body = (preg_replace ('/(?<=^|[\s,_,`,~])(\*(?!\s).+?(?<!\s)\*)/', "<b>$1</b>", $message->body));
+        $message->body = (preg_replace ('/(?<=^|[\s,\*,`,~])(_(?!\s).+?(?<!\s)_)/', "<em>$1</em>", $message->body));
+        $message->body = (preg_replace ('/(?<=^|[\s,\*,_,`])(~(?!\s).+?(?<!\s)~)/', "<s>$1</s>", $message->body));
 
         // Sticker message
         if (isset($message->sticker)) {


### PR DESCRIPTION
From the XEP:

> Spans are always the children of blocks and may not escape from their containing block. Matches of spans between two styling directives MUST contain some text between the two directives, otherwise neither directive is valid. The opening styling directive MUST be located at the beginning of the parent block, after a whitespace character, or after a different opening styling directive. The opening styling directive MUST NOT be followed by a whitespace character and the closing styling directive MUST NOT be preceeded by a whitespace character. Spans are always parsed from the beginning of the byte stream to the end and are lazily matched. Characters that would be styling directives but do not follow these rules are not considered when matching and thus may be present between two other styling directives.