### PR TITLE
Bug/corruptedAvatars

### DIFF
--- a/src/Movim/Image.php
+++ b/src/Movim/Image.php
@@ -208,13 +208,13 @@ class Image
                 $this->_im->setInterlaceScheme(\Imagick::INTERLACE_PLANE);
 
                 // Put 11 as a value for now, see http://php.net/manual/en/imagick.flattenimages.php#116956
-                $this->_im->setImageAlphaChannel(\Imagick::ALPHACHANNEL_REMOVE);
+                $this->_im->setImageAlphaChannel(\Imagick::ALPHACHANNEL_OFF);
                 //$this->_im->setImageAlphaChannel(11);
                 $this->_im->setImageBackgroundColor('#ffffff');
             }
 
             if ($format == 'webp') {
-                $this->_im->setImageAlphaChannel(\Imagick::ALPHACHANNEL_ACTIVATE);
+                $this->_im->setImageAlphaChannel(\Imagick::ALPHACHANNEL_ON);
                 $this->_im->setBackgroundColor(new \ImagickPixel('transparent'));
             }
 


### PR DESCRIPTION
I have an [issue](https://github.com/movim/movim/issues/1046) with my installation, it looks like a really distorted images for avatars.
The setup is like 
php 8.1.12 (but was appearing on earlier versions)
imagemagick 7.1.0.53 (but was appearing on earlier versions)
php-imagick 3.7.0 (but was appearing at least since 3.5.1)

This solution helps but I have no idea if it keeps things in order, please check it!
