### PR TITLE
Hash agility for Bits of Binary

### DIFF
--- a/app/helpers/StringHelper.php
+++ b/app/helpers/StringHelper.php
@@ -158,9 +158,13 @@ function cleanJid($jid): string
  */
 function getCid($string)
 {
-    preg_match("/(\w+)\@/", $string, $matches);
+    preg_match("/(\w+)\+(\w+)\@/", $string, $matches);
     if (is_array($matches) && count($matches) > 1) {
-        return $matches[1];
+        if ($matches[1] === "sha1") {
+            return $matches[2];
+        } else {
+            return $matches[1].'+'.$matches[2];
+        }
     }
 }
 

--- a/app/widgets/Stickers/Stickers.php
+++ b/app/widgets/Stickers/Stickers.php
@@ -30,6 +30,9 @@ class Stickers extends \Movim\Widget\Base
 
         list($c, $ext) = explode('@', $cid);
         list($sh, $key) = explode('+', $c);
+        if ($sh !== "sha1") {
+            $key = $sh.'+'.$key;
+        }
 
         $base64 = base64_encode(file_get_contents(PUBLIC_CACHE_PATH.hash(Image::$hash, $key).'.png'));
 

--- a/lib/moxl/src/Stanza/BOB.php
+++ b/lib/moxl/src/Stanza/BOB.php
@@ -6,9 +6,13 @@ class BOB
 {
     public static function request($to, $cid)
     {
+        if (!strstr($cid, '+')) {
+            $cid = 'sha1+'.$cid;
+        }
+
         $dom = new \DOMDocument('1.0', 'UTF-8');
         $data = $dom->createElementNS('urn:xmpp:bob', 'data');
-        $data->setAttribute('cid', 'sha1+'.$cid.'@bob.xmpp.org');
+        $data->setAttribute('cid', $cid.'@bob.xmpp.org');
 
         if (!empty($cid)) {
             \Moxl\API::request(\Moxl\API::iqWrapper($data, $to, 'get'));


### PR DESCRIPTION
Previously, code assumed bits of binary cids were sha1.  Now, if they are sha1 if uses the previous behaviour, but if they are another algoritm the algorithm is included in the key.  Then 'sha1+' is only prepended to the key when requesting if there is no hash specified already.

Fixes #1092