### PR TITLE
Movim does not support any commands

### DIFF
--- a/lib/moxl/src/Utils.php
+++ b/lib/moxl/src/Utils.php
@@ -66,7 +66,6 @@ class Utils
             //'http://jabber.org/protocol/mood+notify',
             'http://jabber.org/protocol/xhtml-im',
             'http://jabber.org/protocol/chatstates',
-            'http://jabber.org/protocol/commands',
             'http://jabber.org/protocol/caps',
             'http://jabber.org/protocol/disco#info',
             'http://jabber.org/protocol/disco#items',


### PR DESCRIPTION
Movim does support fetching commands from others as a client, but does not serve any commands itself, thus it as at best misleading to advertise support for being a command service.