### PR TITLE
Always store thread id when present

### DIFF
--- a/app/Message.php
+++ b/app/Message.php
@@ -267,9 +267,12 @@ class Message extends Model
                 $this->body = (string)$stanza->body;
             }
 
-
             if ($stanza->subject) {
                 $this->subject = (string)$stanza->subject;
+            }
+
+            if ($stanza->thread) {
+                $this->thread = (string)$stanza->thread;
             }
 
             // XEP-0333: Chat Markers
@@ -291,9 +294,7 @@ class Message extends Model
                         (int)$stanza->fallback->body->attributes()->end
                     );
                 }
-            } else if ($stanza->thread) {
-                $this->thread = (string)$stanza->thread;
-
+            } else if ($this->thread) {
                 $parent = $this->user->messages()
                     ->jid($this->jidfrom)
                     ->where('thread', $this->thread)


### PR DESCRIPTION
Even a reply can itself have a thread id and it can be useful to look it up later.