### PR TITLE
A SIMS message may contain a body along with the image, so show both

### DIFF
--- a/app/widgets/Chat/chat.js
+++ b/app/widgets/Chat/chat.js
@@ -986,31 +986,31 @@ var Chat = {
             msg.setAttribute('dir', 'rtl');
         }
 
+        // OMEMO handling
+        if (data.omemoheader) {
+            p.innerHTML = data.omemoheader.payload.substr(0, data.omemoheader.payload.length / 2);
+            ChatOmemo.decrypt(data).then(plaintext => {
+                let refreshP = document.querySelector('#id' + data.id + ' p.encrypted');
+                if (refreshP) {
+                    if (plaintext) {
+                        let linkified = MovimUtils.linkify(plaintext);
+                        refreshP.innerHTML = ChatOmemo.searchEncryptedFile(linkified);
+                        refreshP.classList.remove('encrypted');
+                    } else {
+                        refreshP.classList.add('error');
+                    }
+                }
+            });
+        } else {
+            p.innerHTML = data.body;
+        }
+
         if (data.sticker != null) {
             bubble.querySelector('div.bubble').classList.add('sticker');
             p.appendChild(Chat.getStickerHtml(data.sticker));
 
             if (data.file != null) {
                 p.classList.add('previewable');
-            }
-        } else {
-            // OMEMO handling
-            if (data.omemoheader) {
-                p.innerHTML = data.omemoheader.payload.substr(0, data.omemoheader.payload.length / 2);
-                ChatOmemo.decrypt(data).then(plaintext => {
-                    let refreshP = document.querySelector('#id' + data.id + ' p.encrypted');
-                    if (refreshP) {
-                        if (plaintext) {
-                            let linkified = MovimUtils.linkify(plaintext);
-                            refreshP.innerHTML = ChatOmemo.searchEncryptedFile(linkified);
-                            refreshP.classList.remove('encrypted');
-                        } else {
-                            refreshP.classList.add('error');
-                        }
-                    }
-                });
-            } else {
-                p.innerHTML = data.body;
             }
         }
 
@@ -1019,7 +1019,7 @@ var Chat = {
 
             // Ugly fix to clear the paragraph if the file contains a similar link
             if (p.querySelector('a') && p.querySelector('a').href == data.file.uri) {
-                p.innerHTML = '';
+                p.querySelector('a').remove();
             }
 
             p.appendChild(Chat.getFileHtml(data.file, data.sticker));


### PR DESCRIPTION
This already worked in the large-file case, but when there is a small file it gets shown "as a sticker" which assumed there was no useful body on the message. Now we put the body in as well.

The possibly-redundant URI body that some clients send is already handled by existing code to clear out the paragraph, though that code could remove the sticker preview entirely so we update it to remove only the offending link here.

Fixes #1079
(That issue says it's about OOB, but Movim actually doesn't support receiving OOB at all, only SIMS, so that is what is implemented here.)