### PR TITLE
Fix scrollbar width in Firefox, move scrollbar specifics to scrollbar.css

### DIFF
--- a/public/theme/css/color.css
+++ b/public/theme/css/color.css
@@ -8,9 +8,6 @@ body {
     --movim-gray: 35, 35, 35;
     --movim-font: 0, 0, 0;
     --movim-element-action: 153, 153, 153;
-    scrollbar-color: rgba(var(--movim-font), 0.2) transparent;
-    scrollbar-width: thin;
-
     --movim-red: #F44336;
 }
 
@@ -20,7 +17,6 @@ body.nightmode {
     --movim-background: 25, 32, 40;
     --movim-gray: var(--movim-accent);
     --movim-font: 255, 255, 255;
-    scrollbar-color: rgba(var(--movim-font), 0.1) transparent;
 }
 
 body {

--- a/public/theme/css/scrollbar.css
+++ b/public/theme/css/scrollbar.css
@@ -1,3 +1,17 @@
+/* Firefox specific CSS for the scrollbars */
+
+* {
+    scrollbar-width: thin;
+}
+
+body {
+    scrollbar-color: rgba(var(--movim-font), 0.2) transparent;
+}
+
+body.nightmode {
+    scrollbar-color: rgba(var(--movim-font), 0.1) transparent;
+}
+
 /* Webkit specific CSS for the scrollbars */
 
 ::-webkit-scrollbar {


### PR DESCRIPTION
Apparently `scrollbar-width` doesn't propagate in Firefox, so it needs to be set for all elements.