### PR TITLE
Fix loading mysql modules

### DIFF
--- a/src/Movim/Daemon/Session.php
+++ b/src/Movim/Daemon/Session.php
@@ -34,14 +34,14 @@ class Session
     private $offset;
 
     private $extensions = [
+        'pdo',
+        'mysqlnd',             // load first
         'xml',
         'imagick',
         'curl',
         'dom',
         'mbstring',
         'mysqli',
-        'mysqlnd',
-        'pdo',
         'pdo_mysql',
         'pdo_pgsql',
         'simplexml'


### PR DESCRIPTION
This fixed a few errors loading the needed modules on my test systems (Devuan, Debian stable), where the native driver is usually configured to be loaded first.