### PR TITLE
Add "json" to the list of modules to load for linker

### DIFF
--- a/src/Movim/Daemon/Session.php
+++ b/src/Movim/Daemon/Session.php
@@ -44,7 +44,8 @@ class Session
         'mysqli',
         'pdo_mysql',
         'pdo_pgsql',
-        'simplexml'
+        'simplexml',
+        'json'
     ];
 
     public function __construct(


### PR DESCRIPTION
Otherwise linker crashes at launch with Debian Bullseye's PHP 7.4.33.