### PR TITLE
Nice UI for adding a contact through a Gateway

### DIFF
--- a/app/Presence.php
+++ b/app/Presence.php
@@ -32,8 +32,7 @@ class Presence extends Model
 
     public function capability()
     {
-        return $this->hasOne('App\Info', 'node', 'node')
-            ->whereNull('server');
+        return $this->hasOne('App\Info', 'node', 'node');
     }
 
     public function contact()

--- a/lib/moxl/src/Xec/Action/IqGateway/Set.php
+++ b/lib/moxl/src/Xec/Action/IqGateway/Set.php
@@ -22,6 +22,7 @@ class Set extends Action
         $this->prepare($stanza, $parent);
         $this->pack([
             'query' => $stanza->query,
+            'prompt' => $this->_prompt,
             'extra' => $this->_extra
         ]);
         $this->deliver();

--- a/src/Movim/Bootstrap.php
+++ b/src/Movim/Bootstrap.php
@@ -278,7 +278,7 @@ class Bootstrap
         'Confirm','ContactActions','Chat','ChatOmemo','Chats','Config','ContactData','ContactHeader',
         'ContactSubscriptions','Dialog','Drawer','Location','Login',
         'Menu','Navigation','Notif', 'Notifications','NewsNav','Post','PostActions',
-        'Presence','Publish','Rooms','RoomsExplore', 'RoomsUtils', 'Stickers','Toast',
+        'Presence','Publish','Rooms','RoomsExplore','RoomsUtils','Search','Stickers','Toast',
         'Upload','Vcard4','Visio','VisioLink'];
     }
 


### PR DESCRIPTION
Uses jabber:iq:gateway where supported (such as slidge and cheogram) and
otherwise falls back to jid escaping where supported, or finally traditional %
escaping.  When searching for contacts, automatically search all gateways that
are added to contacts as well, and show any relevant results.

Note: if the gateway returns an error because the format is bad, this doesn't
show the error since that doesn't really fit the search paradigm, and instead it
simply does not show a result for that gateway.

Also contains a patch to show sms contacts with the "mobile" icon and gateways themselves with the "bot" icon.