### PR TITLE
Use true JID of message sender when we know it

### DIFF
--- a/app/Message.php
+++ b/app/Message.php
@@ -296,9 +296,10 @@ class Message extends Model
             $parentMessage = $this->resolveParentMessage($this->jidfrom, (string)$stanza->reactions->attributes()->id);
 
             if ($parentMessage) {
-                $resource = $this->isMuc()
+                $resource = $this->counterpartjid
+                    ? $this->counterpartjid : ($this->isMuc()
                     ? $this->resource
-                    : $this->jidfrom;
+                    : $this->jidfrom);
 
                 $parentMessage
                     ->reactions()
@@ -585,7 +586,7 @@ class Message extends Model
     public function resolveColor()
     {
         $this->color = stringToColor(
-            $this->resource . $this->type
+            ($this->isMuc() ? $this->resource : ($this->counterpartjid ? $this->counterpartjid : $this->fromjid)) . $this->type
         );
 
         return $this->color;

--- a/app/Message.php
+++ b/app/Message.php
@@ -277,6 +277,17 @@ class Message extends Model
             }
         }
 
+        if ($this->isMuc()) {
+            $presence = $this->user->session->presences()
+                             ->where('jid', $this->jidfrom)
+                             ->where('resource', $this->resource)
+                             ->where('muc', true)
+                             ->first();
+            // If we know the true JID of the sender, save it
+            if ($presence->mucjid != $this->jidfrom.'/'.$this->resource) {
+                $this->counterpartjid = $presence->mucjid;
+            }
+        }
 
         # XEP-0444: Message Reactions
         if (isset($stanza->reactions)

--- a/app/widgets/Chat/_chat_reactions.tpl
+++ b/app/widgets/Chat/_chat_reactions.tpl
@@ -1,5 +1,5 @@
 {loop="$reactions"}
-    <li {if="$message->isMuc()"}title="{$value|implodeCsv}"{/if}
+    <li {if="$attribution"}title="{$value|implodeCsv}"{/if}
         {if="in_array($me, $value)"}class="reacted"{/if}
         onclick="Chat_ajaxHttpDaemonSendReaction('{$message->mid}', '{$key}')">
         {autoescape="off"}

--- a/app/widgets/Chat/chat.js
+++ b/app/widgets/Chat/chat.js
@@ -1110,7 +1110,16 @@ var Chat = {
             reactions.innerHTML = data.reactionsHtml;
         }
 
-        if (isMuc && data.resource) {
+        if (data.contact) {
+            var nick = data.contact.name || (isMuc && data.resource) || data.contact.truename;
+            var resourceSpan = document.createElement('span');
+            resourceSpan.classList.add('resource');
+            resourceSpan.classList.add(data.color);
+            resourceSpan.innerText = nick + (isMuc && data.resource && data.resource != nick ? ' (' + data.resource + ')' : '');
+            resourceSpan.title = data.contact.jid;
+
+            msg.appendChild(resourceSpan);
+        } else if (isMuc && data.resource) {
             var resourceSpan = document.createElement('span');
             resourceSpan.classList.add('resource');
             resourceSpan.classList.add(data.color);
@@ -1188,6 +1197,17 @@ var Chat = {
                 bubble.querySelector('div.bubble').insertBefore(msg, bubble.querySelector('div.bubble').firstChild);
             } else {
                 bubble.querySelector('div.bubble').appendChild(msg);
+            }
+        }
+
+        if (data.icon_url) {
+            icon = bubble.querySelector('span.primary.icon');
+            if (icon.querySelector('img') == undefined) {
+                var img = document.createElement('img');
+                img.setAttribute('src', data.icon_url);
+                icon.appendChild(img);
+            } else {
+                icon.querySelector('img').src = data.icon_url;
             }
         }
 

--- a/database/migrations/20230319022206_add_counterpart_jid_to_messages_table.php
+++ b/database/migrations/20230319022206_add_counterpart_jid_to_messages_table.php
@@ -1,0 +1,13 @@
+<?php
+declare(strict_types=1);
+
+use Phinx\Migration\AbstractMigration;
+
+final class AddCounterpartJidToMessagesTable extends AbstractMigration
+{
+    public function change(): void
+    {
+        $table = $this->table('messages');
+        $table->addColumn('counterpartjid', 'string')->update();
+    }
+}


### PR DESCRIPTION
Save true counterpart JID of MUC sender when we know it.

Set true counterpart JID by XEP-0033 ofrom, but only when it is quite safe, that is when the domain of the ofrom matches the domain of the from, and that domain advertises support for XEP-0033 itself.  (Allowing for fallback body in conjunction with this.)

Show nickname and icon based on true counterpart JID when we know it.