### PR TITLE
Fix #1183  compileOpcache fails with php8.1 

### DIFF
--- a/app/helpers/UtilsHelper.php
+++ b/app/helpers/UtilsHelper.php
@@ -123,8 +123,11 @@ function compileOpcache()
 {
     error_reporting(0);
     foreach (listOpcacheCompilableFiles() as $file) {
-        opcache_invalidate($file, true);
-        yield @opcache_compile_file($file);
+        if (opcache_is_script_cached($file)) {
+            yield @opcache_invalidate($file, true);
+        } else {
+            yield @opcache_compile_file($file);
+        }
     }
     error_reporting(1);
 }


### PR DESCRIPTION
According to https://github.com/movim/movim/issues/1183#issuecomment-1486737189