### PR TITLE
Respect user agent font sizing

### DIFF
--- a/public/theme/css/style.css
+++ b/public/theme/css/style.css
@@ -16,7 +16,7 @@
 }
 
 html {
-    font-size: 8.25px;
+    font-size: 51.5625%;
 }
 
 body {


### PR DESCRIPTION
While the typical user agent font size is `16px`, this value is configurable by the user. Much of this project is built in `rem` unit which are relative to the base which can be helpful to accessibility. However, when a base size is set to `px` the user agent’s font size is no longer respected. This value is a percentage to match the previous `px` value (i.e. 8.25 ÷ 16).

Prior arts typically use 62.5% as it makes `rem`s effectively ⅒ the `px` size which makes the math of converting much easier. Rather than touching all `rem` values, this fix merely is changing the single base value.

[^1]

[^1]: Please consider [giving up MS GitHub](https://sfconservancy.org/GiveUpGitHub/) or offering a non-proprietary, non-US-corporate-controlled mirror for this free software project.
I wish to delete this Microsoft account in the future, but I need more projects like this to support alternative methods to send patches & contribute.