### PR TITLE
Load widgets from absolute path

### DIFF
--- a/src/Movim/Widget/Base.php
+++ b/src/Movim/Widget/Base.php
@@ -238,7 +238,7 @@ class Base
      */
     private function cacheFile(string $filename)
     {
-        $local = '../../app/widgets/' . get_class($this) . '/' . $filename;
+        $local = DOCUMENT_ROOT . '/app/widgets/' . get_class($this) . '/' . $filename;
         $cache = PUBLIC_CACHE_PATH . get_class($this) . '_' . $filename;
         $path = 'cache/' . get_class($this) . '_' . $filename;
 


### PR DESCRIPTION
If the public cache is located or symlinked elsewhere, the relative path lookup fails. In the case of NixOS, stateful storage (e.g. caches) must be located outside of the stateless store where Movim application code lives.

[^1]

[^1]: Please consider [giving up MS GitHub](https://sfconservancy.org/GiveUpGitHub/) or offering a non-proprietary, non-US-corporate-controlled mirror for this free software project.
I wish to delete this Microsoft account in the future, but I need more projects like this to support alternative methods to send patches & contribute.