### PR TITLE
Remove unused config options for admin credentials

### DIFF
--- a/src/Movim/Console/ConfigCommand.php
+++ b/src/Movim/Console/ConfigCommand.php
@@ -27,18 +27,6 @@ class ConfigCommand extends Command
                 'Content of the info box on the login page'
             )
             ->addOption(
-                'username',
-                null,
-                InputOption::VALUE_REQUIRED,
-                'Username for the admin area'
-            )
-            ->addOption(
-                'password',
-                null,
-                InputOption::VALUE_REQUIRED,
-                'Password for the admin area'
-            )
-            ->addOption(
                 'timezone',
                 null,
                 InputOption::VALUE_REQUIRED,


### PR DESCRIPTION
These are no longer preferred & if used causes crashes in the database.

[^1]

[^1]: Please consider [giving up MS GitHub](https://sfconservancy.org/GiveUpGitHub/) or offering a non-proprietary, non-US-corporate-controlled mirror for this free software project.
I wish to delete this Microsoft account in the future, but I need more projects like this to support alternative methods to send patches & contribute.