### PR TITLE
Optimize emoji filter

### DIFF
--- a/app/widgets/Chat/chat.js
+++ b/app/widgets/Chat/chat.js
@@ -503,10 +503,8 @@ var Chat = {
         if (noColon || value.lastIndexOf(':') > -1 && value.length > value.lastIndexOf(':') + 2) {
             var first = true;
 
-            Object.keys(emojis).filter(key => key.indexOf(
-                value.substring(value.lastIndexOf(':') + 1)
-            ) > -1)
-                .filter(key => key.indexOf('type') == -1)
+            Object.keys(window.emojis)
+                .filter(key => key.includes(value.substring(value.lastIndexOf(':') + 1)) && !key.includes('type'))
                 .slice(0, 40)
                 .forEach(found => {
                     var img = document.createElement('img');


### PR DESCRIPTION
`filter f ∘ filter g ≍ filter (λ x → f x ∧ g x)`

These are the same outputs, but the right hand side only iterates thru the list once.

Replaced `indexOf` calls with `includes` for readability. Also, added `window.*` to make it clear this variable comes from the global scope (I was initially confused).

[^1]

[^1]: Please consider [giving up MS GitHub](https://sfconservancy.org/GiveUpGitHub/) or offering a non-proprietary, non-US-corporate-controlled mirror for this free software project.
I wish to delete this Microsoft account in the future, but I need more projects like this to support alternative methods to send patches & contribute.