### PR TITLE
Add missing CLI config options

### DIFF
--- a/app/Configuration.php
+++ b/app/Configuration.php
@@ -11,6 +11,7 @@ class Configuration extends Model
     private static $instance = null;
 
     public $fillable = [
+        'chatonly',
         'description',
         'disableregistration',
         'info',
@@ -30,10 +31,12 @@ class Configuration extends Model
         'id'                    => 1,
         'unregister'            => false,
         'disableregistration'   => false,
+        'chatonly'              => false,
         'restrictsuggestions'   => false,
         'loglevel'              => 0,
         'locale'                => 'en',
-        'xmppwhitelist'         => null
+        'xmppwhitelist'         => null,
+        'gifapikey'             => null,
     ];
 
     public static function get()

--- a/src/Movim/Console/ConfigCommand.php
+++ b/src/Movim/Console/ConfigCommand.php
@@ -27,10 +27,34 @@ class ConfigCommand extends Command
                 'Content of the info box on the login page'
             )
             ->addOption(
+                'description',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'General description of the instance'
+            )
+            ->addOption(
                 'timezone',
                 null,
                 InputOption::VALUE_REQUIRED,
                 'The server timezone'
+            )
+            ->addOption(
+                'restrictsuggestions',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'Only suggest chatrooms, Communities and other contents that are available on the user XMPP server and related services'
+            )
+            ->addOption(
+                'chatonly',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'Disable all the social feature (Communities, Blog…) and keep only the chat ones'
+            )
+            ->addOption(
+                'disableregistration',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'Remove the XMPP registration flow and buttons from the interface'
             )
             ->addOption(
                 'loglevel',
@@ -61,6 +85,12 @@ class ConfigCommand extends Command
                 null,
                 InputOption::VALUE_REQUIRED,
                 'The whitelisted XMPP servers'
+            )
+            ->addOption(
+                'gifapikey',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'Tenor API key'
             );
     }
 


### PR DESCRIPTION
Only some of these values were configurable via CLI. While it seems most options have migrated to the Admin panel, there is still value in allowing these options to be easily configurable without logging in. Use case: NixOS configurations tend to have as many properties as possible in the declarative config rather than using mutable state; as server configurations tend to be configured once then left alone, this feel like the right UX.

Omitted: banner stuff as it isn’t as simple as a line of configuration needing to access the network, process images, upload, etc.

[^1]

[^1]: Please consider [giving up MS GitHub](https://sfconservancy.org/GiveUpGitHub/) or offering a non-proprietary, non-US-corporate-controlled mirror for this free software project.
I wish to delete this Microsoft account in the future, but I need more projects like this to support alternative methods to send patches & contribute.