### PR TITLE
:is(textarea, select):disabled + textarea[readonly]

### DIFF
--- a/public/theme/css/form.css
+++ b/public/theme/css/form.css
@@ -300,13 +300,18 @@ form > div .radio > input[type="radio"]:checked + label:hover {
 /* Disabled */
 
 form > div input:disabled,
-form > div input:disabled + label {
+form > div input:disabled + label,
+form > div select:disabled,
+form > div select:disabled + label,
+form > div textarea:disabled,
+form > div textarea:disabled + label {
     opacity: 0.5;
 }
 
 /* Readonly */
 
-form > div input[readonly] {
+form > div input[readonly],
+form > div textarea[readonly] {
     opacity: 0.75;
 }
 


### PR DESCRIPTION
These form elements were missing the same styles as their more common `<input>` brother.

[^1]

[^1]: Please consider [giving up MS GitHub](https://sfconservancy.org/GiveUpGitHub/) or offering a non-proprietary, non-US-corporate-controlled mirror for this free software project.
I wish to delete this Microsoft account in the future, but I need more projects like this to support alternative methods to send patches & contribute.