### PR TITLE
Unauthed `dir` + language refactor

### DIFF
--- a/src/Movim/Template/Builder.php
+++ b/src/Movim/Template/Builder.php
@@ -140,10 +140,14 @@ class Builder
      */
     public function language(): string
     {
-        $lang = $this->user && $this->user->language
-            ? $this->user->language
-            : Configuration::get()->locale;
-        return Locale::printISO639($lang);
+        if ($this?->user?->language != null) {
+            return Locale::printISO639($this->user->language);
+        }
+
+        $locale = Locale::start();
+        $locale->detect(getenv('language'));
+
+        return Locale::printISO639($locale->language ?? Configuration::get()->locale);
     }
 
     /**

--- a/src/Movim/Template/Builder.php
+++ b/src/Movim/Template/Builder.php
@@ -21,6 +21,7 @@ class Builder
     private array $css = [];
     private array $scripts = [];
     private string $eagerScripts = "/\/(movim_rpc|movim_utils)/";
+    private string $lang = Locale::DEFAULT_LANGUAGE;
     private string $dir = 'ltr';
     private bool $public;
     private ?User $user = null;
@@ -141,13 +142,16 @@ class Builder
     public function language(): string
     {
         if ($this?->user?->language != null) {
-            return Locale::printISO639($this->user->language);
+            $this->lang = $this->user->language;
+            return Locale::printISO639($this->lang);
         }
 
         $locale = Locale::start();
         $locale->detect(getenv('language'));
 
-        return Locale::printISO639($locale->language ?? Configuration::get()->locale);
+        $this->lang = Locale::printISO639($locale->language ?? Configuration::get()->locale);
+
+        return $this->lang;
     }
 
     /**

--- a/src/Movim/Template/Builder.php
+++ b/src/Movim/Template/Builder.php
@@ -9,6 +9,7 @@ use App\Configuration;
 use App\User;
 use Movim\Controller\Ajax;
 use Movim\Widget\Wrapper;
+use Movim\i18n\Dir;
 use Movim\i18n\Locale;
 use stdClass;
 
@@ -22,7 +23,7 @@ class Builder
     private array $scripts = [];
     private string $eagerScripts = "/\/(movim_rpc|movim_utils)/";
     private string $lang = Locale::DEFAULT_LANGUAGE;
-    private string $dir = 'ltr';
+    private Dir $dir = Locale::DEFAULT_DIRECTION;
     private bool $public;
     private ?User $user = null;
     private $jsCheck = true;
@@ -78,7 +79,7 @@ class Builder
 
         $outp = str_replace(
             ['<%scripts%>', '<%meta%>', '<%content%>', '<%common%>', '<%title%>', '<%language%>', '<%dir%>'],
-            [$scripts, $this->meta(), $this->content, $this->commonContent, $this->title(), $this->language(), $this->dir()],
+            [$scripts, $this->meta(), $this->content, $this->commonContent, $this->title(), $this->language(), $this->dir()->value],
             $outp
         );
 
@@ -157,13 +158,13 @@ class Builder
     /**
      * Displays the current font direction
      */
-    public function dir()
+    public function dir(): Dir
     {
         if (isLogged()) {
             $lang = \App\User::me()->language;
 
             if (in_array($lang, ['ar', 'he', 'fa'])) {
-                $this->dir = 'rtl';
+                $this->dir = \Movim\i18n\Locale\Dir::RTL;
             }
         }
 

--- a/src/Movim/Template/Builder.php
+++ b/src/Movim/Template/Builder.php
@@ -160,14 +160,7 @@ class Builder
      */
     public function dir(): Dir
     {
-        if (isLogged()) {
-            $lang = \App\User::me()->language;
-
-            if (in_array($lang, ['ar', 'he', 'fa'])) {
-                $this->dir = \Movim\i18n\Locale\Dir::RTL;
-            }
-        }
-
+        $this->dir = \Movim\i18n\Locale::getDirection($this->lang);
         return $this->dir;
     }
 

--- a/src/Movim/Template/Builder.php
+++ b/src/Movim/Template/Builder.php
@@ -9,6 +9,7 @@ use App\Configuration;
 use App\User;
 use Movim\Controller\Ajax;
 use Movim\Widget\Wrapper;
+use Movim\i18n\Locale;
 use stdClass;
 
 class Builder
@@ -142,37 +143,7 @@ class Builder
         $lang = $this->user && $this->user->language
             ? $this->user->language
             : Configuration::get()->locale;
-
-        if (empty($lang)) {
-            return 'en';
-        }
-
-        // String casing for the web
-        $split = array_slice(preg_split('/[_-]/', $lang), 0, 3);
-        $lc = array_shift($split);
-        $langCode = strtolower($lc);
-
-        if (empty($split)) {
-           return $langCode;
-        }
-
-        $tags = array_map(function ($tag) {
-            switch (strlen($tag)) {
-                // Region
-                case 2:
-                case 3:
-                   return strtoupper($tag);
-                // Script
-                case 4:
-                   return ucfirst(strtolower($tag));
-                default:
-                   return $tag;
-            }
-        }, $split);
-
-        array_unshift($tags, $langCode);
-
-        return implode('-', $tags);
+        return Locale::printISO639($lang);
     }
 
     /**

--- a/src/Movim/i18n/Locale.php
+++ b/src/Movim/i18n/Locale.php
@@ -6,11 +6,20 @@
 
 namespace Movim\i18n;
 
+enum Dir: string
+{
+    case LTR = 'ltr';
+    case RTL = 'rtl';
+};
+
 class Locale
 {
     private static $instance;
     public const DEFAULT_LANGUAGE = 'en';
+    public const DEFAULT_DIRECTION = Dir::LTR;
     public const LOCALE_REGEXP = '(?<language>[a-z]{2,8})(?:[-_](?<script>[A-Za-z][a-z]{3}))?(?:[-_](?<region>[A-Za-z]{2,3}|[0-9]{3}))?';
+    public const RTL_LANGUAGES = ['ar', 'he', 'fa', 'ur', 'ps', 'syr', 'dv'];
+    public const RTL_SCRIPTS = ['Adlm', 'Arab', 'Aran', 'Armi', 'Avst', 'Cprt', 'Hebr', 'Khar', 'Lydi', 'Mand', 'Mani', 'Mend', 'Narb', 'Nbat', 'Nkoo', 'Orkh', 'Palm', 'Phli', 'Phlp', 'Phnx', 'Prti', 'Samr', 'Sarb', 'Syrc', 'Thaa'];
     public $translations;
     public $language;
     public $hash = [];
@@ -347,6 +356,24 @@ class Locale
         if (isset($matches[1])) {
             return $matches[1];
         }
+    }
+
+    /**
+     * @desc Determine the direction of a locale string
+     */
+    public static function getDirection(string $str): Dir
+    {
+        $loc = locale_parse($str);
+
+        if (empty($loc)) {
+            return self::DEFAULT_DIRECTION;
+        }
+
+        if (isset($loc['script'])) {
+            return in_array($loc['script'], self::RTL_SCRIPTS) ? Dir::RTL : Dir::LTR;
+        }
+
+        return in_array($loc['language'], self::RTL_LANGUAGES) ? Dir::RTL : Dir::LTR;
     }
 
     /**

--- a/src/Movim/i18n/Locale.php
+++ b/src/Movim/i18n/Locale.php
@@ -363,7 +363,7 @@ class Locale
      */
     public static function getDirection(string $str): Dir
     {
-        $loc = locale_parse($str);
+        $loc = self::parseStr($str);
 
         if (empty($loc)) {
             return self::DEFAULT_DIRECTION;

--- a/src/Movim/i18n/Locale.php
+++ b/src/Movim/i18n/Locale.php
@@ -330,4 +330,30 @@ class Locale
             return $matches[1];
         }
     }
+
+    /**
+     * @desc Converts a string to Locale, then prints as an ISO-639-compatbile string
+     */
+    public static function printISO639(string $str): string
+    {
+        $parsed = self::parseStr($str);
+        return is_array($parsed) ? implode('-', array_values($parsed)) : $str;
+    }
+
+    /**
+     * @desc Converts a string to Locale, then prints as an POSIX-compatbile string
+     */
+    public static function printPOSIX(string $str): string
+    {
+        $parsed = self::parseStr($str);
+        return is_array($parsed) ? implode('_', array_values($parsed)) : $str;
+    }
+
+    /**
+     * @desc Converts a string to Locale, then prints as an PO-filename-compatbile string
+     */
+    public static function printPo(string $str): string
+    {
+        return strtolower(self::printPOSIX($str));
+    }
 }

--- a/src/Movim/i18n/Locale.php
+++ b/src/Movim/i18n/Locale.php
@@ -260,7 +260,7 @@ class Locale
      */
     public function load(string $language)
     {
-        $this->language = $language;
+        $this->language = $this->printPo($language);
         $this->loadPo();
     }
 

--- a/src/Movim/i18n/Locale.php
+++ b/src/Movim/i18n/Locale.php
@@ -9,6 +9,7 @@ namespace Movim\i18n;
 class Locale
 {
     private static $instance;
+    public const LOCALE_REGEXP = '(?<language>[a-z]{2,8})(?:[-_](?<script>[A-Za-z][a-z]{3}))?(?:[-_](?<region>[A-Za-z]{2,3}|[0-9]{3}))?';
     public $translations;
     public $language;
     public $hash = [];
@@ -173,6 +174,37 @@ class Locale
         } else {
             \Utils::info('Locale: Translation key "' . $key . '" not found');
             return $arr[1];
+        }
+    }
+
+    /**
+     * @desc Poor man’s locale_parse, but looking to save dependencies & resources
+     */
+    public static function parseStr(string $str): ?array {
+        if (preg_match('/' . self::LOCALE_REGEXP . '/', $str, $loc)) {
+            self::reformatLocalePartsToISO639($loc);
+            return $loc;
+        }
+
+        return null;
+    }
+
+    private static function reformatLocalePartsToISO639(array &$locale) {
+        foreach ($locale as $key => &$value) {
+            if (is_numeric($key) || empty($value)) {
+                unset($locale[$key]);
+            } else {
+                $locale[$key] = match ($key) {
+                    'language' => strtolower($value),
+                    'script' => ucfirst(strtolower($value)),
+                    'region' => strtoupper($value),
+                    default => $value,
+                };
+            }
+        };
+
+        if (empty($locale)) {
+            $locale = null;
         }
     }
 


### PR DESCRIPTION
I didn’t realize that `dir` was missing & lang wasn’t as robust as it should be--& neither worked for unauthenticated users. And speaking of not being robust, the Regex for language parsing has a bug in where if a user sends a script (such as [Serbian](https://en.wikipedia.org/wiki/Serbian_language) that uses both Cyrillic & Latin, with code such as `sr-Latn-RS`), we can get a bug. That code wasn’t the easiest to read so I did a refactor on the block to use named captures as I think it’s easier to read/follow.

This will likely be easiest to read by commit.

[^1]

[^1]: Please consider [giving up MS GitHub](https://sfconservancy.org/GiveUpGitHub/) or offering a non-proprietary, non-US-corporate-controlled mirror for this free software project.
I wish to delete this Microsoft account in the future, but I need more projects like this to support alternative methods to send patches & contribute.