### PR TITLE
Oppose nav bottom without absolute or media query

### DIFF
--- a/public/theme/css/menu.css
+++ b/public/theme/css/menu.css
@@ -14,15 +14,7 @@ body>nav.color.dark>ul a {
 }
 
 ul.oppose {
-    position: absolute;
-    bottom: 0;
-    width: 100%;
-}
-
-@media screen and (max-height: 28rem) {
-    ul.oppose {
-        bottom: initial;
-    }
+    margin-top: auto;
 }
 
 /* Specific case to handle rtl */

--- a/public/theme/css/style.css
+++ b/public/theme/css/style.css
@@ -57,6 +57,8 @@ a:visited {
 /* Navigation bar */
 
 body>nav {
+    display: flex;
+    flex-flow: column nowrap;
     width: 7rem;
     max-width: 95%;
     z-index: 2;


### PR DESCRIPTION
``margin-top: auto;`` in a flex model allows this to ‘float’ to the bottom without the bugginess of absolute positioning (my setup with the dev tools open on bottom caused navigation icon overlap).

[^1]

[^1]: Please consider [giving up MS GitHub](https://sfconservancy.org/GiveUpGitHub/) or offering a non-proprietary, non-US-corporate-controlled mirror for this free software project.
I wish to delete this Microsoft account in the future, but I need more projects like this to support alternative methods to send patches & contribute.