### PR TITLE
Extend suggested nginx websocket proxy timeouts.

### DIFF
--- a/src/Movim/Daemon/Core.php
+++ b/src/Movim/Daemon/Core.php
@@ -84,6 +84,8 @@ class Core implements MessageComponentInterface
     proxy_set_header X-Forwarded-For \$proxy_add_x_forwarded_for;
     proxy_set_header X-Forwarded-Proto https;
     proxy_redirect off;
+    proxy_read_timeout 1800s;
+    proxy_send_timeout 1800s;
 }
 ";
 


### PR DESCRIPTION
With nginx running as a reverse proxy, movim frequently "flashes", displaying a toast, as its websocket is closed and reopened.  When this happens frequently the current chat log is often pulled down to the most recent message, making it hard to read a chat buffer backlog.

This most often occurs at times of low message traffic, such as when most of Europe is asleep.  Low message traffic reduces the frequency of websocket message flow, leading nginx to close the websocket due to proxy timeouts.

The default proxy timeout is sixty seconds.  Increasing the timeout leads to smoother backlog reading.