### PR TITLE
Use string casting for senders attribute

### DIFF
--- a/src/Movim/Librairies/JingletoSDP.php
+++ b/src/Movim/Librairies/JingletoSDP.php
@@ -133,7 +133,7 @@ class JingletoSDP
                                     'both' => 'sendrecv',
                                 ];
 
-                                $sdpMedia .= '/' . $sendersToDirection[$payload->attributes()->senders];
+                                $sdpMedia .= '/' . $sendersToDirection[(string)$payload->attributes()->senders];
                             }
 
                             $sdpMedia .= ' ' . $payload->attributes()->uri;


### PR DESCRIPTION
Potential fix for movim/movim#1327.

Tested: voice and video calls are now available again for different Firefox users.
