### PR TITLE
Fix #1182 Moxl Handler: Match <received> carbons to Carbons class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ v0.27.2 (master)
 * Fix the screen sharing and webcam switch buttons
 * CSS and UI fixes
 * Handle the session_down event to disconnect the call properly when the browser is not reachable after a while
+* Fix carbons for received messages being ignored (#1182)
 
 v0.27.1
 ---------------------------

--- a/src/Moxl/Xec/Handler.php
+++ b/src/Moxl/Xec/Handler.php
@@ -174,8 +174,8 @@ class Handler
             '44d0c16e222fcdee6961c8939b647e15' => 'JingleReject',
             'd84d4b89d43e88a244197ccf499de8d8' => 'Jingle',
 
-            '09ef1b34cf40fdd954f10d6e5075ee5c' => 'Carbons',
-            //'201fa54dd93e3403611830213f5f9fbc' => 'Carbons', //?
+            '09ef1b34cf40fdd954f10d6e5075ee5c' => 'Carbons', // sent
+            '201fa54dd93e3403611830213f5f9fbc' => 'Carbons', // received
 
             'da6b60476aeab672ac0afe3ff27dc6a4' => 'OMEMODevices',
 


### PR DESCRIPTION
Otherwise carbons for incoming messages are silently ignored.

Fixes 5a03d2bb745b ("Ensuring that the MUC is having urn:xmpp:sid:0 to set the stanza-id, related to #1106")