### PR TITLE
Fix XMPP & Mastodon links in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,8 @@ Links
 -----
 * Movim official website: https://movim.eu/
 * You can join one of the Movim instances on https://join.movim.eu/
-* Mastodon: @movim@piaille.fr
-* XMPP Chatroom: movim@conference.movim.eu
+* Mastodon: [@movim@piaille.fr](https://piaille.fr/@movim)
+* XMPP Chatroom: [movim@conference.movim.eu](xmpp:movim@conference.movim.eu)
 * Twitter: https://twitter.com/MovimNetwork
 
 Translations


### PR DESCRIPTION
The XMPP and Mastodon links were being displayed as emails, so I have changed them as such:

- Use [XMPP URIs](https://xmpp.org/extensions/xep-0147.html) for the XMPP room
- Use a link to the mastodon page for the Mastodon identifier