### PR TITLE
add minimal H2O server YAML config file

### DIFF
--- a/etc/h2o/h2o.yaml
+++ b/etc/h2o/h2o.yaml
@@ -1,0 +1,30 @@
+# Minimal H2O configuration for Movim
+#
+# Read the H2O documentation <https://h2o.examp1e.net/configure.html> on how to
+# set up TLS, compression, security headers, & so on.
+
+hosts:
+  movim.domain.tld:80:
+    listen:
+      port: 80
+    file.custom-handler:
+      extension:
+      - .php
+      fastcgi.connect:
+        port: /run/phpfpm/movim.sock
+        type: unix
+      fastcgi.document_root: /var/www/movim
+    paths:
+      /:
+        file.dir: /var/www/movim/public
+        file.index:
+        - index.php
+        - index.html
+        redirect:
+          internal: 'YES'
+          status: 307
+          url: /index.php/
+      /ws/:
+        proxy.preserve-host: 'ON'
+        proxy.reverse.url: http://127.0.0.1:8080/
+        proxy.tunnel: 'ON'


### PR DESCRIPTION
I recently switched to H2O on NixOS (hoping to avoid Nginx config hell). There is an open pull request on the Nixpkgs Microsoft GitHub forge <https://github.com/NixOS/nixpkgs/pull/385040> with tests to add H2O module support to the NixOS module using a similar setup via `services.movim.config`. That config is less minimal tho since I can expect things like precompressed assets, but less is probably more here.

[^1]

[^1]: Please consider [giving up MS GitHub](https://sfconservancy.org/GiveUpGitHub/) or offering a non-proprietary, non-US-corporate-controlled mirror for this free software project. I wish to delete this Microsoft account in the future, but I need more projects like this to support alternative methods to send patches & contribute.