### PR TITLE
Set versions and use full path to images

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,4 +1,4 @@
-FROM serversideup/php:8.4-fpm-nginx-alpine
+FROM docker.io/serversideup/php:8.4-fpm-nginx-alpine3.21
 
 USER root
 

--- a/podman-compose.yml
+++ b/podman-compose.yml
@@ -1,6 +1,6 @@
 services:
   db:
-    image: 'postgres:latest'
+    image: 'docker.io/postgres:18.3-trixie'
     environment:
       POSTGRES_USER: movim
       POSTGRES_PASSWORD: movim


### PR DESCRIPTION
Make the "Quick Test" https://github.com/movim/movim#quick-test use verified and working versions.
Using full path to registries, default configuration of podman and/or different distributions does not default to docker.io.