### PR TITLE
Added check to  UtilsHelper to increase FreeBSD support

### DIFF
--- a/app/Helpers/UtilsHelper.php
+++ b/app/Helpers/UtilsHelper.php
@@ -213,6 +213,13 @@ function requiredExtensions(): array
         'xml',
     ];
 
+    // These are included in PHP on most platforms,
+    // but FreeBSD provides them as extensions still
+    if (php_uname('s') == 'FreeBSD') {
+        array_push($extensions, 'filter');
+        array_push($extensions, 'zlib');
+        array_push($extensions, 'zip');
+    }
     // ext-json is included in PHP since 8.0
     if (version_compare(PHP_VERSION, '8.0.0') < 0) {
         array_push($extensions, 'json');


### PR DESCRIPTION
FreeBSD has a few PHP extensions that are part of PHP core on other systems, so requiredExtensions() needs to return those if the server is running FreeBSD.