### PR TITLE
Feat: Add attachment icons and MIME-type handling

### DIFF
--- a/app/Helpers/UtilsHelper.php
+++ b/app/Helpers/UtilsHelper.php
@@ -1090,3 +1090,58 @@ function base64ToFingerPrint(string $base64): string
     $hex = unpack('H*', $buffer);
     return implode(' ', str_split(substr($hex[1], 2), 8));
 }
+
+/**
+ * @desc Return a Material Symbols icon name for a given mimetype
+ */
+function mimeToIcon(string $type): string
+{
+    return match(true) {
+        $type === 'application/pdf'
+            => 'picture_as_pdf',
+        (bool)preg_match('/^application\/(zip|x-zip|x-tar|x-rar|x-7z|gzip|x-bzip)/', $type)
+            => 'folder_zip',
+        (bool)preg_match('/^application\/(msword|vnd\.oasis\.opendocument\.text|vnd\.openxmlformats-officedocument\.wordprocessingml)/', $type)
+            => 'description',
+        (bool)preg_match('/^application\/(vnd\.ms-excel|vnd\.oasis\.opendocument\.spreadsheet|vnd\.openxmlformats-officedocument\.spreadsheetml)/', $type)
+            => 'table_chart',
+        (bool)preg_match('/^application\/(vnd\.ms-powerpoint|vnd\.oasis\.opendocument\.presentation|vnd\.openxmlformats-officedocument\.presentationml)/', $type)
+            => 'slideshow',
+        (bool)preg_match('/^text\/(html|xml|css|javascript)/', $type),
+        (bool)preg_match('/^application\/(json|xml|javascript)/', $type)
+            => 'code',
+        (bool)preg_match('/^text\//', $type)
+            => 'article',
+        typeIsAudio($type) => 'audio_file',
+        typeIsVideo($type) => 'video_file',
+        typeIsPicture($type) => 'image',
+        default => 'insert_drive_file',
+    };
+}
+
+/**
+ * @desc Return a short uppercase label from a mimetype (such as 'application/pdf' -> 'PDF')
+ */
+function mimeToLabel(string $type): string
+{
+    $subtype = explode('/', $type)[1] ?? '';
+
+    return strtoupper(match(true) {
+	$type === 'application/pdf'                                                      => 'pdf',
+        str_starts_with($subtype, 'vnd.openxmlformats-officedocument.wordprocessingml') => 'docx',
+        str_starts_with($subtype, 'vnd.openxmlformats-officedocument.spreadsheetml')    => 'xlsx',
+        str_starts_with($subtype, 'vnd.openxmlformats-officedocument.presentationml')   => 'pptx',
+        str_starts_with($subtype, 'vnd.oasis.opendocument.text')                        => 'odt',
+        str_starts_with($subtype, 'vnd.oasis.opendocument.spreadsheet')                 => 'ods',
+        str_starts_with($subtype, 'vnd.oasis.opendocument.presentation')                => 'odp',
+        str_starts_with($subtype, 'vnd.ms-excel')                                       => 'xls',
+        str_starts_with($subtype, 'vnd.ms-powerpoint')                                  => 'ppt',
+        $subtype === 'x-tar'                                                             => 'tar',
+        $subtype === 'x-7z-compressed'                                                  => '7z',
+        $subtype === 'x-bzip2'                                                           => 'bz2',
+        $subtype === 'x-rar'                                                             => 'rar',
+        $subtype === 'x-zip'                                                             => 'zip',
+        $subtype === 'msword'                                                            => 'doc',
+        default                                                                          => $subtype,
+    });
+}

--- a/app/Widgets/Chat/Chat.php
+++ b/app/Widgets/Chat/Chat.php
@@ -1516,8 +1516,10 @@ class Chat extends \Movim\Widget\Base
                         $message->body = '';
                     }
                 }
-            } elseif (isset($message->file) && $message->file->type != 'xmpp') {
-                $message->body = '';
+            } elseif (isset($message->file) && $message->file->type != 'xmpp' && !$message->file->preview) {
+                $view = $this->tpl();
+                $view->assign('file', $message->file);
+                $message->card = $view->draw('_chat_file');
             }
         }
 

--- a/app/Widgets/Chat/_chat_file.tpl
+++ b/app/Widgets/Chat/_chat_file.tpl
@@ -1,0 +1,11 @@
+<li class="block">
+    <span class="primary icon bubble gray">
+        <i class="material-symbols fill">{$file->type|mimeToIcon}</i>
+    </span>
+    <div>
+        <p><a href="{$file->url}" target="_blank" rel="noopener noreferrer">{$file->name}</a></p>
+        {if="$file->cleansize"}
+            <p>{$file->cleansize} · {$file->type|mimeToLabel}</p>
+        {/if}
+    </div>
+</li>


### PR DESCRIPTION
This PR adds icons to messages with file attachments, based on their MIME type. This is done primarily on the PHP side instead of JS which was the approach taken in #1539. 

This is how it looks right now:

<img width="798" height="671" alt="image" src="https://github.com/user-attachments/assets/ec25445a-ee82-47dc-8e8e-48e57d157644" />
