### PR TITLE
fix: ignore audio and video attachments

### DIFF
--- a/app/Widgets/Chat/Chat.php
+++ b/app/Widgets/Chat/Chat.php
@@ -1517,7 +1517,11 @@ class Chat extends \Movim\Widget\Base
                     }
                 }
             } elseif (isset($message->file) && $message->file->type != 'xmpp') {
-                if (!$message->file->preview) {
+                if (
+                    !$message->file->preview
+                    && !typeIsAudio($message->file->type)
+                    && !typeIsVideo($message->file->type)
+                ) {
                     $view = $this->tpl();
                     $view->assign('file', $message->file);
                     $message->card = $view->draw('_chat_file');


### PR DESCRIPTION
audio and video files are to be directly played, so they must not be considered as other 'attachments'