### PR TITLE
Fix: No longer send the MuJi call end event in the DM or as contacts.

### DIFF
--- a/app/Widgets/Visio/Visio.php
+++ b/app/Widgets/Visio/Visio.php
@@ -110,7 +110,12 @@ class Visio extends Base
 
     public function onCallInviteRetract(Packet $packet)
     {
-        $this->ajaxClear();
+        $muji = $packet->content;
+        if ($muji && $muji->id) {
+            $this->ajaxLeaveMuji($muji->id);
+        } else {
+            $this->ajaxClear();
+        }
     }
 
     public function onExternalServices(Packet $packet)
@@ -485,8 +490,6 @@ class Visio extends Base
                     ->setResource($resource)
                     ->request();
 
-                $this->me->session->mujiCalls()->where('id', $mujiId)->delete();
-
                 (new Rooms($this->me, sessionId: $this->sessionId))->onPresence($muji->jidfrom);
 
                 // If we were the inviter, we also retract the call
@@ -496,6 +499,8 @@ class Visio extends Base
                     $retract->setTo($muji->jidfrom)
                         ->setId($muji->id)
                         ->request();
+                } else {
+                    $this->me->session->mujiCalls()->where('id', $mujiId)->delete();
                 }
             }
 
@@ -800,6 +805,12 @@ class Visio extends Base
      */
     public function ajaxGoodbye(string $to, string $sid, ?string $reason = 'success')
     {
+        // If this is a muji call, delegate to the proper leave handler
+        $currentCall = $this->currentCall();
+        if ($currentCall->isStarted() && $currentCall->mujiRoom) {
+            $this->ajaxLeaveMuji($sid);
+            return;
+        }
         if ($this->currentCall()->isStarted()) {
             $this->currentCall()->stop($to, $sid);
             $st = $this->xmpp(new MessageFinish);
@@ -843,19 +854,24 @@ class Visio extends Base
             && $currentCall->hasId($id)
             && $currentCall->isJidInCall($jid)
         ) {
-            $message = Message::eventMessageFactory(
-                $this->me,
-                'jingle',
-                bareJid($currentCall->jid),
-                $currentCall->id
-            );
-            $message->type = 'jingle_finish';
-            $message->save();
-
-            Wrapper::getInstance()->iterate('jingle_message', (new Packet)->pack($message), user: $this->me, sessionId: $this->sessionId);
-
-            $this->ajaxTerminate($currentCall->jid, $currentCall->id, 'gone');
-            $this->ajaxGoodbye($currentCall->jid, $currentCall->id, 'gone');
+            if (!$currentCall->mujiRoom) {
+                $message = Message::eventMessageFactory(
+                    $this->me,
+                    'jingle',
+                    bareJid($currentCall->jid),
+                    $currentCall->id
+                );
+                $message->type = 'jingle_finish';
+                $message->save();
+                Wrapper::getInstance()->iterate('jingle_message',
+                                                (new Packet)->pack($message),
+                                                user: $this->me,
+                                                sessionId: $this->sessionId);
+                $this->ajaxTerminate($currentCall->jid, $currentCall->id, 'gone');
+                $this->ajaxGoodbye($currentCall->jid, $currentCall->id, 'gone');
+            } else {
+                $this->ajaxLeaveMuji($currentCall->id);
+            }
         }
     }
 

--- a/public/scripts/movim_jingles.js
+++ b/public/scripts/movim_jingles.js
@@ -691,10 +691,15 @@ var MovimJingles = {
     },
 
     terminateAll: function (reason) {
+        let isMuji = document.querySelector('#visio').dataset.muji == 'true';
         for (jid of Object.keys(MovimJingles.sessions)) {
-            MovimJingles.terminate(jid, reason);
+            if (isMuji) {
+                MovimJingles.sessions[jid].close();
+                delete MovimJingles.sessions[jid];
+            } else {
+                MovimJingles.terminate(jid, reason);
+            }
         }
-
         Visio_ajaxClear();
     }
 }

--- a/src/Moxl/Xec/Payload/JingleFinish.php
+++ b/src/Moxl/Xec/Payload/JingleFinish.php
@@ -13,7 +13,7 @@ class JingleFinish extends Payload
 
         $from = (string)$parent->attributes()->from;
 
-        if (!$stanza->muji) {
+        if (!linker($this->me->session->id)->currentCall->mujiRoom) {
             $message = Message::eventMessageFactory(
                 $this->me,
                 'jingle',


### PR DESCRIPTION
Previously when you are in a Muji call, and end it, the end event message wouldn't appear in the MUC but rather in the contact DMs of all the people in the Muji or as a separate contact with the name of the MUC.

This fix handles that properly and sends the call event message to the MUC only.