### PR TITLE
Make Containerfile create public/images directory

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -36,6 +36,9 @@ RUN rm -rf cache; \
     rm -rf public/cache; \
     mkdir public/cache; \
     chown -R www-data:www-data public/cache; \
+    rm -rf public/images; \
+    mkdir public/images; \
+    chown -R www-data:www-data public/images; \
     rm -rf log; \
     mkdir log; \
     chown -R www-data:www-data log/


### PR DESCRIPTION
The current container image fails to start the Movim daemon for me. Instead, this error message is repeated every few seconds:

```
Can’t create /var/www/html/public/images/ directory
You can create them yourself or let the daemon create them for you.
In both case they should be writable by the same system user that is running the daemon.
```

Ensuring that the container creates the `public/images` directory resolves this issue. In any case, it probably is best that the container explicitly create all the directories it needs.