### PR TITLE
Allow JIDs where the domain part does not have a TLD suffix

### DIFF
--- a/app/Widgets/Login/login.tpl
+++ b/app/Widgets/Login/login.tpl
@@ -56,7 +56,7 @@
                 name="login">
                 <div {if="$maxsessionsreached"}class="disabled"{/if}>
                     <input type="text" id="complete" tabindex="-1"/>
-                    <input type="text" pattern="^.+@.+\..{2,10}$" name="username" id="username" autofocus required
+                    <input type="text" pattern="^.+@.+$" name="username" id="username" autofocus required
                         placeholder="username@server.com" >
                     <label for="username">{$c->__('form.username')}</label>
                 </div>


### PR DESCRIPTION
The regex mandated a dot and a suffix in the JID used to login. However, this is incorrect, eg, test@localhost is a valid JID. This commit allows anything@anything to login.