### PR TITLE
Improve container

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -1,0 +1,18 @@
+name: Build and publish a Docker image to ghcr.io
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  docker_publish:
+    runs-on: "ubuntu-24.04"
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Build and publish a Docker image for ${{ github.repository }}
+        uses: macbre/push-to-ghcr@master
+        with:
+          dockerfile: Containerfile
+          image_name: ${{ github.repository }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/Containerfile
+++ b/Containerfile
@@ -2,17 +2,19 @@ FROM docker.io/serversideup/php:8.4-fpm-nginx-alpine3.21
 
 USER root
 
+# PHP
+RUN install-php-extensions imagick gd bcmath
+
 # S6
 COPY ./etc/s6-overlay/s6-rc.d/movim-migrations/ /etc/s6-overlay/s6-rc.d/movim-migrations/
 COPY ./etc/s6-overlay/s6-rc.d/movim-daemon/ /etc/s6-overlay/s6-rc.d/movim-daemon/
+COPY ./etc/s6-overlay/s6-rc.d/tail-log/ /etc/s6-overlay/s6-rc.d/tail-log/
 RUN touch /etc/s6-overlay/s6-rc.d/user/contents.d/movim-migrations
 RUN touch /etc/s6-overlay/s6-rc.d/user/contents.d/movim-daemon
+RUN touch /etc/s6-overlay/s6-rc.d/user/contents.d/tail-log
 
 # nginx websocket
 COPY /etc/nginx/conf.d/movim-websocket.conf /etc/nginx/server-opts.d/
-
-# PHP
-RUN install-php-extensions imagick gd bcmath
 
 # Movim
 
@@ -22,25 +24,29 @@ ENV DAEMON_INTERFACE=127.0.0.1
 ENV DAEMON_PORT=8083
 ENV NGINX_WEBROOT=/var/www/html/public
 
-ADD . /var/www/html
 WORKDIR /var/www/html
 
-RUN cd /var/www/html
-RUN composer install
-# Ensure that the host .env is not copied
-RUN rm -rf /var/www/.env
 # Setup some directories
-RUN rm -rf cache; \
-    mkdir cache; \
+RUN mkdir cache; \
     chown -R www-data:www-data cache; \
-    rm -rf public/cache; \
-    mkdir public/cache; \
-    chown -R www-data:www-data public/cache; \
-    rm -rf public/images; \
-    mkdir public/images; \
-    chown -R www-data:www-data public/images; \
-    rm -rf log; \
     mkdir log; \
-    chown -R www-data:www-data log/
+    chown -R www-data:www-data log
+
+# install 3rd party dependencies
+COPY composer.lock composer.json .
+RUN composer install
+
+COPY .php_cs phinx.php daemon.php VERSION .
+COPY config ./config
+COPY locales ./locales
+COPY public ./public
+RUN mkdir -p public/cache; \
+    chown -R www-data:www-data public/cache; \
+    mkdir public/images; \
+    chown -R www-data:www-data public/images
+COPY workers ./workers
+COPY database ./database
+COPY src ./src
+COPY app ./app
 
 USER www-data

--- a/README.md
+++ b/README.md
@@ -35,6 +35,9 @@ You can then access in your browser at the following URL:
 
 The container is using a self-signed certificate, accept to get to the login page.
 
+The container is also available at `ghcr.io/movim/movim:latest`, but requires
+postgresql to run (cf our podman-compose script).
+
 Security report
 ---------------
 

--- a/etc/s6-overlay/s6-rc.d/tail-log/dependencies
+++ b/etc/s6-overlay/s6-rc.d/tail-log/dependencies
@@ -1,0 +1,1 @@
+movim-daemon

--- a/etc/s6-overlay/s6-rc.d/tail-log/run
+++ b/etc/s6-overlay/s6-rc.d/tail-log/run
@@ -1,0 +1,2 @@
+#!/command/with-contenv sh
+tail -F /var/www/html/log/errors.log /var/www/html/log/debug.log /var/www/html/log/info.log -q 2> /dev/null

--- a/etc/s6-overlay/s6-rc.d/tail-log/type
+++ b/etc/s6-overlay/s6-rc.d/tail-log/type
@@ -1,0 +1,1 @@
+longrun


### PR DESCRIPTION
Some small improvements while trying to investigate https://github.com/movim/movim/issues/1576

I marked this as WIP because I want to push some more improvements in here. @edhelas would you agree in principle with the following changes, if I ever submit them?

- [ ] ~Disable SSL entirely. The practice is usually to have containers do PLAIN and put them behind a reverse proxy. Moreover, here, the container is for development more than deployment, so we care even less about SSL.~
- [ ] ~Have postgresql run in the same container too. We have a frankenstein-y situation here, where several services are spawned in the movim container, but then we need postgresql in another one too. For deployment it's usually considered good practice to have one process per container, but I think we're aiming at a development-oriented container here, so I think it would even be more convenient to let go of ssl all along?~
- [x] Have it built and pushed to ghcr.io in github actions