### PR TITLE
fix HTML escaping in encrypted messages

### DIFF
--- a/app/Widgets/Chat/chat.js
+++ b/app/Widgets/Chat/chat.js
@@ -1177,13 +1177,10 @@ var Chat = {
                 let refreshP = document.querySelector('#id' + data.id + ' p.encrypted');
                 if (refreshP) {
                     if (plaintext) {
-                        if (typeof refreshP.setHTML == 'function') {
-                            let linkified = MovimUtils.linkify(plaintext);
-                            refreshP.setHTML(ChatOmemo.searchEncryptedFile(linkified));
-                        } else {
-                            // Safari doesn't support setHTML yet...
-                            refreshP.innerText = ChatOmemo.searchEncryptedFile(plaintext);
-                        }
+                        // Escape the message to prevent HTML injection.
+                        let escaped = new Option(plaintext).innerHTML;
+                        let linkified = MovimUtils.linkify(escaped);
+                        refreshP.innerHTML = ChatOmemo.searchEncryptedFile(linkified);
 
                         refreshP.classList.remove('encrypted');
                     } else {


### PR DESCRIPTION
The original fix only sanitized the plaintext from XSS-unsafe HTML
elements, however it is not desirable to render any HTML injected by the
sender.

Also, the original fix performed escaping after scanning the message for
file uploads which would also escape the safe HTML displaying the file
download icon (although only at the Safari variant).

---

I have not tested this as I don't have a Movim instance set up.
