### PR TITLE
Fix iOS Safari image upload sending empty request body

### DIFF
--- a/app/Widgets/Upload/upload.js
+++ b/app/Widgets/Upload/upload.js
@@ -194,7 +194,20 @@ var Upload = {
                 ctx = Upload.canvas.getContext("2d");
                 ctx.drawImage(image, 0, 0, image.naturalWidth, image.naturalHeight);
 
-                Upload.prepare(file);
+                // Always create a fresh Blob from the canvas for iOS Safari.
+                // The original File reference becomes invalid after async gaps,
+                // producing Content-Length: 0 uploads on Safari.
+                if (typeof Upload.canvas.toBlob == 'function') {
+                    Upload.canvas.toBlob(
+                        function (blob) {
+                            Upload.prepare(blob);
+                        },
+                        file.type,
+                        1.0
+                    );
+                } else {
+                    Upload.prepare(file);
+                }
             }
         });
         image.src = src;


### PR DESCRIPTION
The original File reference from <input type='file'> becomes invalid on iOS Safari after any async gap (FileReader, Image load). When the image is small (<= SMALL_PICTURE_LIMIT), the file was passed through two async hops before being appended to FormData, resulting in Content-Length: 0 uploads.

Now the small-image path also creates a fresh Blob from the canvas via canvas.toBlob(), matching the large-image path behaviour.

Fixes #1621

tested in iOS 26.6.1
<img width="514" height="511" alt="image" src="https://github.com/user-attachments/assets/14a689f1-d728-4edb-a12f-dc2d34ebd7ac" />
